### PR TITLE
feat!: v0.5.0 Action Broker — signed policies, out-of-band approval, chained audit, output DLP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,14 @@ jobs:
         shell: bash
         run: |
           package="dist/open-guardian"
-          mkdir -p "$package/rules" "$package/docs/adr" "$package/benchmarks/corpus"
+          mkdir -p "$package/rules" "$package/docs/adr" "$package/benchmarks/corpus" "$package/examples"
           cp "target/${{ matrix.platform.target }}/release/${{ matrix.platform.binary }}" "$package/"
           cp guardian.toml README.md CHANGELOG.md LICENSE "$package/"
           cp rules/*.toml "$package/rules/"
           cp docs/adr/*.md "$package/docs/adr/"
-          cp docs/BENCHMARK.md "$package/docs/"
+          cp docs/BENCHMARK.md docs/BROKER.md docs/RELEASING.md "$package/docs/"
           cp benchmarks/corpus/*.toml "$package/benchmarks/corpus/"
+          cp examples/*.toml "$package/examples/"
           tar -C dist -czf "dist/${{ matrix.platform.archive }}" open-guardian
 
       - name: Stage Windows package
@@ -91,13 +92,14 @@ jobs:
         shell: pwsh
         run: |
           $package = "dist/open-guardian"
-          New-Item -ItemType Directory -Force "$package/rules", "$package/docs/adr", "$package/benchmarks/corpus" | Out-Null
+          New-Item -ItemType Directory -Force "$package/rules", "$package/docs/adr", "$package/benchmarks/corpus", "$package/examples" | Out-Null
           Copy-Item "target/${{ matrix.platform.target }}/release/${{ matrix.platform.binary }}" $package
           Copy-Item guardian.toml, README.md, CHANGELOG.md, LICENSE $package
           Copy-Item rules/*.toml "$package/rules/"
           Copy-Item docs/adr/*.md "$package/docs/adr/"
-          Copy-Item docs/BENCHMARK.md "$package/docs/"
+          Copy-Item docs/BENCHMARK.md, docs/BROKER.md, docs/RELEASING.md "$package/docs/"
           Copy-Item benchmarks/corpus/*.toml "$package/benchmarks/corpus/"
+          Copy-Item examples/*.toml "$package/examples/"
           Compress-Archive -Path $package -DestinationPath "dist/${{ matrix.platform.archive }}"
 
       - name: Upload package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v0.5.0 - Action Broker: privileged actions with out-of-band approval (2026-08-22)
+
+### New
+
+- **Action Broker daemon** (`open-guardian broker start`): executes
+  allowlisted privileged actions on behalf of AI agents behind four gates —
+  ed25519-**signed policies** (exact argv, no shell; tampered or unsigned
+  policies refuse to start), **out-of-band approval** (6-char code visible
+  only on the operator channel; wrong codes are audited and rejected),
+  **hash-chained audit**, and **output DLP** (command stdout/stderr runs
+  through the same DLP engine as the proxy; obfuscated secrets suppress the
+  whole output). Loopback-only IPC with separate agent/admin bearer tokens.
+- **MCP server** (`open-guardian mcp`): stdio transport via the official Rust
+  SDK (`rmcp`), three tools (`guardian_list_actions`,
+  `guardian_request_action`, `guardian_request_status`), harness-agnostic
+  (Claude Code, Cursor, Goose, …). The agent channel can never see approval
+  codes or approve anything.
+- **Operator CLI**: `approve` (code prompt or `--code`/`--yes`), `deny`,
+  `requests` (shows pending codes), `broker request` (terminal testing), and
+  `policy keygen|sign|verify|sudoers` (surgical
+  `/etc/sudoers.d/guardian-broker` lines with `visudo -f` instructions).
+- **Hash-chained audit log**: every security event (proxy and broker) is now
+  written as JSONL with `seq`/`prev`/`hash` linking; `open-guardian verify`
+  walks the chain and reports edits, deletions, or reordering with line
+  numbers. One chain per process (proxy and broker keep separate files).
+- **Secrets in executed actions**: policy env entries are `{{secret:...}}`
+  references resolved only at execution time and injected straight into the
+  child's environment (env/keychain/vault backends); unresolvable references
+  abort the action before anything runs. Results are delivered exactly once
+  and expire (Vault response-wrapping semantics; Teleport-style pending →
+  approve/deny → TTL state machine).
+- Docs: [docs/BROKER.md](docs/BROKER.md) (architecture, honest threat model,
+  sudoers guide), `examples/broker-policy.toml`.
+
+### Changed
+
+- Audit log lines gain `seq`, `prev`, and `hash` fields (previously plain
+  JSONL). Existing logs remain readable; `open-guardian verify` validates the
+  new format.
+
 ## v0.4.0 - The proof: regression-gated leak benchmark (2026-08-22)
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,7 +623,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -859,7 +868,23 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -874,6 +899,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -935,6 +994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1019,34 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519",
+ "sha2 0.11.0",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1036,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1080,6 +1177,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-crate"
@@ -1663,7 +1766,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1758,6 +1861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1895,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1953,6 +2064,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,12 +2183,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2145,6 +2284,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,7 +2342,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-guardian"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "age",
  "anyhow",
@@ -2174,16 +2352,20 @@ dependencies = [
  "clap",
  "colored",
  "dotenvy",
+ "ed25519-dalek",
  "futures-util",
  "hex",
  "hmac-sha256",
  "html-escape",
  "http",
  "keyring",
+ "notify-rust",
  "rand 0.8.7",
  "regex",
  "reqwest",
+ "rmcp",
  "rpassword",
+ "schemars",
  "serde",
  "serde_json",
  "service-manager",
@@ -2289,8 +2471,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -2536,7 +2724,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2631,6 +2819,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2926,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -2814,7 +3057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2889,6 +3132,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -3008,6 +3277,17 @@ name = "serde_derive"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3144,6 +3424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.19",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,7 +3565,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3767,6 +4064,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3952,7 +4250,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3962,6 +4260,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,9 +4302,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3998,6 +4342,12 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -4016,14 +4366,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4032,7 +4401,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4048,11 +4417,20 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4079,7 +4457,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4096,6 +4474,24 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4176,7 +4572,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.18.0"
+version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
 dependencies = [
  "futures-lite",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-guardian"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -11,9 +11,13 @@ keywords = ["ai", "security", "dlp", "llm", "proxy"]
 categories = ["network-programming"]
 
 [features]
-default = ["native-keyring", "portable-vault"]
+default = ["native-keyring", "portable-vault", "mcp", "desktop-notify"]
 native-keyring = ["dep:keyring", "dep:rpassword"]
 portable-vault = ["dep:age", "zeroize/serde"]
+# MCP tool server for AI agent harnesses (open-guardian mcp)
+mcp = ["dep:rmcp", "dep:schemars"]
+# Desktop notification cue for pending broker approvals (Unix only)
+desktop-notify = ["dep:notify-rust"]
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
@@ -51,6 +55,18 @@ hex = "0.4"
 unicode-normalization = "0.1"
 html-escape = "0.2"
 urlencoding = "2.1"
+
+# Action broker (v0.5): signed policies + MCP tool surface
+ed25519-dalek = { version = "3.0.0", default-features = false, features = ["fast", "zeroize"] }
+rmcp = { version = "=3.1.4", optional = true, default-features = false, features = [
+    "server",
+    "macros",
+    "transport-io",
+] }
+schemars = { version = "1.0", optional = true, default-features = false }
+
+[target.'cfg(unix)'.dependencies]
+notify-rust = { version = "4.18", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rmcp = { version = "=3.1.4", optional = true, default-features = false, features
 schemars = { version = "1.0", optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-notify-rust = { version = "4.18", optional = true }
+notify-rust = { version = "=4.17.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,28 @@ ruleset and the normalization pipeline are what earn the zero.
 | Response inspection | All responses (including SSE) are buffered to a 16 MiB bound and structurally inspected — a secret split across SSE chunks cannot slip through; non-UTF-8 or malformed declared-JSON bodies fail closed. |
 | Credentials | Provider keys live in env/keychain/age vault and are injected **only** into the upstream `Authorization` header — never in prompts, URLs, or logs. |
 | Rule integrity | Opt-in HMAC-SHA256 manifests over rule files (`open-guardian sign`); tampering fails startup. |
+| Audit chain | Security events (proxy and broker) are hash-chained JSONL; `open-guardian verify` flags edits, deletions, and reordering. |
+
+## Action Broker (v0.5): privileged actions, zero credentials to the agent
+
+The egress proxy stops data leaving; the **Action Broker** lets the agent *do*
+things safely. It exposes allowlisted system actions (`systemctl restart
+nginx`, deploy scripts, …) over MCP and CLI behind four gates: an
+**ed25519-signed policy** (exact argv, no shell), **out-of-band approval**
+(a 6-char code that never crosses the agent channel), **hash-chained audit**
+(`open-guardian verify` detects any tampering), and **output DLP** (the same
+engine, applied to command output — a script echoing a token returns
+`<STRIPE-KEY>` instead).
+
+```console
+$ open-guardian broker request deploy-site "nightly deploy"
+✔ Request 4ddbc0b9 created — awaiting operator approval.
+$ open-guardian approve 4ddbc0b9 --code xquupe    # operator terminal
+✔ approved; executing.  exit_code: 0
+```
+
+Any MCP client works (`open-guardian mcp`, stdio, official Rust SDK). Full
+design, threat model, and sudoers guide in [docs/BROKER.md](docs/BROKER.md).
 
 ## Quick start
 
@@ -174,10 +196,10 @@ design.
 
 ## Roadmap
 
-- **v0.5 — Action Broker**: privileged system actions (restart nginx, apt
-  upgrade) for agents via MCP + CLI with signed policies, out-of-band
-  approval, surgical sudoers, and chained audit — the agent uses the
-  credential without ever seeing it. Harness-agnostic by design.
+- **v0.5 — Action Broker** ✔ *shipped*: privileged system actions for agents
+  via MCP + CLI with signed policies, out-of-band approval, surgical sudoers,
+  and chained audit — the agent uses the credential without ever seeing it.
+  Harness-agnostic by design. See [docs/BROKER.md](docs/BROKER.md).
 - **v0.6 — Context DLP**: sanitizing tool/command output before it enters
   model context.
 

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -4,7 +4,7 @@
 > by hand: CI regenerates this document and rejects drift, and any leak or
 > missed detection on the gated corpus fails the build.
 
-- Engine: open-guardian v0.4.0
+- Engine: open-guardian v0.5.0
 - Rules file: `rules/secrets.toml` (5806 bytes, 27 rules)
 - Corpus: 73 cases
 

--- a/docs/BROKER.md
+++ b/docs/BROKER.md
@@ -1,0 +1,184 @@
+# Action Broker (v0.5)
+
+The Action Broker lets an AI agent run **privileged, allowlisted actions**
+(`systemctl restart nginx`, deploy scripts, …) without ever holding a
+credential and without any in-band approval the agent could grant itself.
+
+Four gates stand between the agent and the command:
+
+1. **Signed policy** — an ed25519-signed TOML file lists the exact argv the
+   agent may ever request. One flipped byte after signing and the daemon
+   refuses to start.
+2. **Out-of-band approval** — every request needs a human typing the
+   6-character approval code in a separate terminal. The code never crosses
+   the agent channel.
+3. **Chained audit** — every event (requested, approved, executed, delivered)
+   lands in a hash-chained JSONL log; `open-guardian verify` detects any edit,
+   deletion, or reordering.
+4. **Output DLP** — stdout/stderr pass through the same DLP engine as the
+   egress proxy: secrets and PII are redacted, obfuscated secrets suppress the
+   whole output.
+
+The design borrows proven pieces instead of inventing: the request state
+machine follows Teleport's `tsh request` (pending → approve/deny → TTL →
+auto-expire), one-time result delivery follows Vault's response-wrapping
+semantics (single reader, bounded life), and secrets reach the child process
+the 1Password `op run` way — resolved at execution time, injected into the
+child's environment only, never returned to the caller.
+
+## Quickstart
+
+```console
+# 1. Keypair (secret key stays offline; the .pub is pinned in config)
+$ open-guardian policy keygen --key broker/policy.key
+
+# 2. Write broker/policy.toml (see examples/broker-policy.toml), then sign it
+$ open-guardian policy sign --policy broker/policy.toml --key broker/policy.key
+
+# 3. Point guardian.toml at both files
+$ cat guardian.toml
+[broker]
+policy = "broker/policy.toml"
+public_key = "broker/policy.pub"
+audit_log_path = "guardian_broker_audit.jsonl"
+
+# 4. (Unix, elevated actions only) install the generated sudoers rules
+$ open-guardian policy sudoers --user "$USER"   # prints /etc/sudoers.d/ lines
+
+# 5. Start the daemon
+$ open-guardian broker start
+BROKER listening on 127.0.0.1:xxxx (N actions). ...
+
+# 6. From another terminal (the agent side, or a real MCP harness)
+$ open-guardian broker request restart-nginx "nightly reload"
+✔ Request 4ddbc0b9 created (pending) — awaiting operator approval.
+
+# 7. Operator approves — the code lives ONLY on this channel
+$ open-guardian requests
+4ddbc0b9  pending  restart-nginx  nightly reload  code: xquupe
+$ open-guardian approve 4ddbc0b9 --code xquupe
+✔ Request 4ddbc0b9 approved; executing.
+  exit_code: 0
+
+# 8. Tamper-evidence
+$ open-guardian verify guardian_broker_audit.jsonl
+✔ Audit chain OK: 11 events, tip 65f4a916cf45e439
+```
+
+## MCP integration (harness-agnostic)
+
+`open-guardian mcp` speaks Model Context Protocol over stdio using the
+official Rust SDK, so any MCP client works (Claude Code, Cursor, Goose, …):
+
+```json
+{ "mcpServers": { "guardian": { "command": "open-guardian", "args": ["mcp"] } } }
+```
+
+Three tools, all agent-channel only:
+
+| Tool | Purpose |
+|---|---|
+| `guardian_list_actions` | What the signed policy allows |
+| `guardian_request_action` | Request one (returns a request id; **never** a code) |
+| `guardian_request_status` | Poll; the sanitized result is delivered exactly once |
+
+## Architecture
+
+```
+MCP harness ──stdio── open-guardian mcp ──┐
+                                          │ loopback HTTP + agent token
+                                          ▼
+                              open-guardian broker start
+                              (daemon, unprivileged user)
+                                 ├─ signed policy (ed25519)
+                                 ├─ SecretBroker → child env only
+                                 ├─ DlpEngine on stdout/stderr
+                                 └─ hash-chained audit log
+                                          ▲
+Operator CLI ─────────────────────────────┘ loopback HTTP + admin token
+(approve / deny / requests — the only channel that sees codes)
+```
+
+- The daemon binds **127.0.0.1 only** on an ephemeral port. Two bearer tokens
+  are written as discovery files (mode 0600) in `$XDG_RUNTIME_DIR`:
+  `guardian-broker.json` (agent: request/status) and
+  `guardian-broker-admin.json` (operator: everything). The agent token
+  physically cannot reach the approve/deny endpoints or the approval codes.
+- Requests expire after `pending_ttl_secs` (default 120); results are kept
+  `result_ttl_secs` (default 300) and are readable **exactly once** — the
+  first reader (operator or agent) consumes them.
+- Commands execute with the **exact argv from the policy** — no shell, no
+  arguments from the agent. Elevated actions run through
+  `sudo -n -u <user> -- <argv>`.
+- Secret references (`{{secret:env://…}}`, `{{secret:keychain://…}}`,
+  `{{secret:vault://…}}`) resolve inside the daemon at execution time and are
+  injected into the child's environment. If any reference fails to resolve,
+  **nothing executes**.
+
+## Sudoers (surgical, Unix only)
+
+For each action with `user = "…"`, `open-guardian policy sudoers` prints one
+exact-match line:
+
+```
+guardian-broker ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx
+```
+
+Install with `visudo -f /etc/sudoers.d/guardian-broker`. Run the daemon as a
+dedicated unprivileged user (`guardian-broker` above); the broker itself never
+needs root. Never allowlist a binary the daemon user can write.
+
+## Threat model — what this does and does not stop
+
+**Stops**: the agent exfiltrating credentials (it only ever sees DLP-sanitized
+output), executing anything not in the signed policy, self-approving (the code
+never crosses the agent channel), silent history rewriting (hash chain), and
+policy tampering (signature).
+
+**Does not stop** (be honest with yourself): an agent that can already execute
+arbitrary shell commands **as your user** can read the discovery files and run
+`open-guardian approve --yes`. The approval code and the two-token split raise
+the bar and make misuse loud (audited, desktop notification, visible in the
+daemon log), but the real boundary on a compromised same-user host is the
+sudoers rule set and how far `user =` targets reach. Run the daemon under its
+own OS user if you need a hard boundary.
+
+**Windows**: the broker works without elevation (`user =` unset). sudo-based
+elevation is Unix-only; policies that set `user` refuse to execute on Windows.
+
+## Configuration reference
+
+```toml
+[broker]
+policy = "broker/policy.toml"        # required (signed)
+public_key = "broker/policy.pub"     # required (pinned ed25519 key, hex)
+audit_log_path = "guardian_broker_audit.jsonl"
+pending_ttl_secs = 120               # approval window
+result_ttl_secs = 300                # one-time result retention
+```
+
+Policy format (full example in `examples/broker-policy.toml`):
+
+```toml
+version = 1
+
+[[action]]
+id = "restart-nginx"                 # lowercase kebab-case, unique
+description = "Restart nginx"
+exec = ["/usr/bin/systemctl", "restart", "nginx"]   # literal argv, no shell
+user = "root"                        # optional sudo target
+timeout_secs = 30                    # 1..=600
+output = "redact"                    # "redact" (default) | "suppress"
+
+[[action.env]]                       # optional, resolved at exec time
+name = "DEPLOY_TOKEN"
+reference = "{{secret:env://DEPLOY_TOKEN}}"
+```
+
+## Audit events
+
+`policy_loaded`, `broker_started`, `action_requested`, `action_approve_rejected`,
+`action_approved`, `action_denied`, `action_expired`, `action_executed`
+(exit code + duration, never output), `result_delivered`, `broker_stopped` —
+each chained with `seq`/`prev`/`hash` fields; `open-guardian verify <file>`
+walks and validates the chain.

--- a/examples/broker-policy.toml
+++ b/examples/broker-policy.toml
@@ -1,0 +1,55 @@
+# Example Action Broker policy (v0.5).
+#
+# 1. Edit the actions to match your machine (absolute paths, exact argv).
+# 2. open-guardian policy keygen --key broker/policy.key
+# 3. open-guardian policy sign --policy broker/policy.toml --key broker/policy.key
+# 4. Pin the key in guardian.toml:
+#        [broker]
+#        policy = "broker/policy.toml"
+#        public_key = "broker/policy.pub"
+#
+# The daemon refuses to start if the signature does not verify, so treat every
+# edit as "edit → re-sign → restart broker".
+
+version = 1
+
+# ── Unprivileged action: runs as the daemon's own user ──────────────────────
+
+[[action]]
+id = "disk-usage"
+description = "Check disk usage"
+exec = ["/bin/df", "-h", "/"]
+timeout_secs = 5
+
+# ── Elevated action: exact sudoers rule + sudo -n -u root ───────────────────
+
+[[action]]
+id = "restart-nginx"
+description = "Restart the nginx service"
+exec = ["/usr/bin/systemctl", "restart", "nginx"]
+user = "root"
+timeout_secs = 30
+
+# ── Secret-bearing action: credential resolved at exec time only ────────────
+# The agent requests the deploy; DEPLOY_TOKEN never appears in any prompt,
+# response, or log — only inside the child process environment.
+
+[[action]]
+id = "deploy-site"
+description = "Run the site deploy script (uses the pinned deploy token)"
+exec = ["/usr/local/bin/deploy-site"]
+timeout_secs = 300
+
+[[action.env]]
+name = "DEPLOY_TOKEN"
+reference = "{{secret:env://DEPLOY_TOKEN}}"
+
+# ── Dangerous-output action: never return stdout at all ─────────────────────
+
+[[action]]
+id = "db-maintenance"
+description = "Nightly database maintenance (output suppressed)"
+exec = ["/usr/local/bin/db-maintain", "--nightly"]
+user = "dbadmin"
+timeout_secs = 600
+output = "suppress"

--- a/guardian.toml
+++ b/guardian.toml
@@ -88,3 +88,16 @@ credential = "{{secret:env://GROQ_API_KEY}}"
 url = "https://api.openai.com/v1"
 model = "gpt-4-turbo"
 credential = "{{secret:env://OPENAI_API_KEY}}"
+
+# ==========================================
+# ACTION BROKER (v0.5) — uncomment to enable
+# ==========================================
+# Privileged actions for AI agents behind a signed policy, out-of-band
+# approval, chained audit, and output DLP. See docs/BROKER.md.
+#
+# [broker]
+# policy = "broker/policy.toml"        # signed with `open-guardian policy sign`
+# public_key = "broker/policy.pub"     # pinned ed25519 key
+# audit_log_path = "guardian_broker_audit.jsonl"
+# pending_ttl_secs = 120               # approval window
+# result_ttl_secs = 300                # one-time result retention

--- a/src/broker/client.rs
+++ b/src/broker/client.rs
@@ -1,0 +1,175 @@
+//! Loopback IPC client shared by the operator CLI and the MCP server.
+
+use super::ipc;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct BrokerClient {
+    base: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+/// Only consumed by the MCP server (`open-guardian mcp`).
+#[cfg_attr(not(feature = "mcp"), allow(dead_code))]
+#[derive(Debug, Deserialize)]
+pub struct ActionSummary {
+    pub id: String,
+    pub description: String,
+    pub requires_elevation: bool,
+}
+
+#[cfg_attr(not(feature = "mcp"), allow(dead_code))]
+#[derive(Debug, Deserialize)]
+pub struct RequestCreated {
+    pub request_id: String,
+    pub status: String,
+    #[serde(default)]
+    pub expires_in_secs: Option<u64>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RequestEntry {
+    pub id: String,
+    pub action_id: String,
+    #[serde(default)]
+    pub reason: String,
+    pub status: String,
+    #[serde(default)]
+    pub code: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // reason/message/error exist for API completeness and CLI/MCP evolution
+pub struct StatusReport {
+    pub request_id: String,
+    pub action_id: String,
+    #[serde(default)]
+    pub reason: String,
+    pub status: String,
+    #[serde(default)]
+    pub result: Option<Value>,
+    #[serde(default)]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl BrokerClient {
+    pub fn new(addr: &str, token: &str) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .context("cannot build broker client")?;
+        Ok(Self {
+            base: format!("http://{addr}"),
+            token: token.to_string(),
+            http,
+        })
+    }
+
+    /// Operator channel: full power (approve/deny/list).
+    pub fn admin() -> Result<Self> {
+        if let (Ok(addr), Ok(token)) = (
+            std::env::var("GUARDIAN_BROKER_URL"),
+            std::env::var("GUARDIAN_BROKER_TOKEN"),
+        ) {
+            return Self::new(&addr, &token);
+        }
+        let (addr, token) = ipc::read_discovery(ipc::ADMIN_DISCOVERY_FILE)?;
+        Self::new(&addr, &token)
+    }
+
+    /// Agent channel: request + status only.
+    #[cfg_attr(not(feature = "mcp"), allow(dead_code))]
+    pub fn agent() -> Result<Self> {
+        if let (Ok(addr), Ok(token)) = (
+            std::env::var("GUARDIAN_BROKER_URL"),
+            std::env::var("GUARDIAN_BROKER_AGENT_TOKEN"),
+        ) {
+            return Self::new(&addr, &token);
+        }
+        let (addr, token) = ipc::read_discovery(ipc::AGENT_DISCOVERY_FILE)?;
+        Self::new(&addr, &token)
+    }
+
+    async fn post<T: for<'de> Deserialize<'de>>(&self, path: &str, body: Value) -> Result<T> {
+        let response = self
+            .http
+            .post(format!("{}{path}", self.base))
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("broker request {path} failed"))?;
+        let status = response.status();
+        let payload: Value = response
+            .json()
+            .await
+            .context("broker returned a malformed response")?;
+        if !status.is_success() {
+            let detail = payload
+                .get("message")
+                .or_else(|| payload.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error");
+            anyhow::bail!("broker: {detail} (HTTP {})", status.as_u16());
+        }
+        serde_json::from_value(payload)
+            .with_context(|| format!("broker response for {path} did not match the expected shape"))
+    }
+
+    #[cfg_attr(not(feature = "mcp"), allow(dead_code))]
+    pub async fn list_actions(&self) -> Result<Vec<ActionSummary>> {
+        #[derive(Deserialize)]
+        struct ActionsResponse {
+            actions: Vec<ActionSummary>,
+        }
+        let response: ActionsResponse = self.post("/v1/actions", Value::Null).await?;
+        Ok(response.actions)
+    }
+
+    pub async fn request_action(&self, action_id: &str, reason: &str) -> Result<RequestCreated> {
+        self.post(
+            "/v1/request",
+            serde_json::json!({ "action_id": action_id, "reason": reason }),
+        )
+        .await
+    }
+
+    pub async fn approve(&self, request_id: &str, code: Option<&str>, yes: bool) -> Result<Value> {
+        self.post(
+            "/v1/approve",
+            serde_json::json!({ "request_id": request_id, "code": code, "yes": yes }),
+        )
+        .await
+    }
+
+    pub async fn deny(&self, request_id: &str) -> Result<Value> {
+        self.post("/v1/deny", serde_json::json!({ "request_id": request_id }))
+            .await
+    }
+
+    pub async fn status(&self, request_id: &str) -> Result<StatusReport> {
+        self.post(
+            "/v1/status",
+            serde_json::json!({ "request_id": request_id }),
+        )
+        .await
+    }
+
+    pub async fn list_requests(&self) -> Result<Vec<RequestEntry>> {
+        #[derive(Deserialize)]
+        struct RequestsResponse {
+            requests: Vec<RequestEntry>,
+        }
+        let response: RequestsResponse = self.post("/v1/requests", Value::Null).await?;
+        Ok(response.requests)
+    }
+}

--- a/src/broker/execute.rs
+++ b/src/broker/execute.rs
@@ -1,0 +1,350 @@
+//! Command execution: argv exact, no shell, secrets only in the child's
+//! environment, output DLP-sanitized before anyone reads it.
+
+use super::policy::{ActionDef, OutputPolicy};
+use super::state::ActionResult;
+use crate::security::{normalize_for_matching, DlpEngine};
+use open_guardian::secrets::SecretBroker;
+use std::time::Instant;
+
+/// Captured stdout/stderr are capped here before sanitization.
+const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+
+const SUPPRESSED_BY_POLICY: &str = "[output suppressed by policy]";
+const SUPPRESSED_BY_DLP: &str = "[output suppressed: potential obfuscated sensitive data detected]";
+
+/// Runs one allowlisted action and returns a fully sanitized result. This
+/// function never returns Err: execution problems (missing binary, timeout,
+/// unresolvable secret) become an `ActionResult` with `error` set, which is
+/// safe to expose.
+pub async fn execute_action(
+    action: &ActionDef,
+    secret_broker: &SecretBroker,
+    dlp: &DlpEngine,
+) -> ActionResult {
+    let started = Instant::now();
+
+    #[cfg(windows)]
+    if action.user.is_some() {
+        // A signed policy with a `user` target cannot be honored on Windows;
+        // refuse rather than silently dropping the elevation boundary.
+        return ActionResult {
+            exit_code: None,
+            duration_ms: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            truncated: false,
+            suppressed: false,
+            error: Some(
+                "action requires elevation via sudo, which is not available on Windows; nothing executed"
+                    .into(),
+            ),
+        };
+    }
+
+    // Secrets resolve here and nowhere else — straight into the child's env.
+    let mut command = build_command(action);
+    for binding in &action.env {
+        match secret_broker.resolve(&binding.reference).await {
+            Ok(value) => {
+                command.env(&binding.name, value.expose_secret());
+            }
+            Err(error) => {
+                return ActionResult {
+                    exit_code: None,
+                    duration_ms: started.elapsed().as_millis() as u64,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    truncated: false,
+                    suppressed: false,
+                    error: Some(format!(
+                        "secret {} could not be resolved: {} (action refused, nothing executed)",
+                        binding.name, error
+                    )),
+                };
+            }
+        }
+    }
+
+    let output = match tokio::time::timeout(
+        std::time::Duration::from_secs(action.timeout_secs),
+        command.output(),
+    )
+    .await
+    {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => {
+            return ActionResult {
+                exit_code: None,
+                duration_ms: started.elapsed().as_millis() as u64,
+                stdout: String::new(),
+                stderr: String::new(),
+                truncated: false,
+                suppressed: false,
+                error: Some(format!("failed to start {}: {error}", action.exec[0])),
+            };
+        }
+        Err(_) => {
+            return ActionResult {
+                exit_code: None,
+                duration_ms: started.elapsed().as_millis() as u64,
+                stdout: String::new(),
+                stderr: String::new(),
+                truncated: false,
+                suppressed: false,
+                error: Some(format!(
+                    "timed out after {}s (process killed)",
+                    action.timeout_secs
+                )),
+            };
+        }
+    };
+
+    let (stdout, stdout_truncated) = truncate(&String::from_utf8_lossy(&output.stdout));
+    let (stderr, stderr_truncated) = truncate(&String::from_utf8_lossy(&output.stderr));
+
+    ActionResult {
+        exit_code: output.status.code(),
+        duration_ms: started.elapsed().as_millis() as u64,
+        stdout: sanitize(action.output, dlp, &stdout),
+        stderr: sanitize(action.output, dlp, &stderr),
+        truncated: stdout_truncated || stderr_truncated,
+        suppressed: action.output == OutputPolicy::Suppress,
+        error: None,
+    }
+}
+
+fn build_command(action: &ActionDef) -> tokio::process::Command {
+    #[cfg(unix)]
+    if let Some(user) = &action.user {
+        // Exact-argv sudoers rule: NOPASSWD, non-interactive, no shell.
+        let mut sudo = tokio::process::Command::new("sudo");
+        sudo.arg("-n").arg("-u").arg(user).arg("--");
+        sudo.arg(&action.exec[0]).args(&action.exec[1..]);
+        return sudo;
+    }
+
+    let mut command = tokio::process::Command::new(&action.exec[0]);
+    command.args(&action.exec[1..]);
+    command
+}
+
+/// Caps a captured stream, cutting on a char boundary.
+fn truncate(text: &str) -> (String, bool) {
+    if text.len() <= MAX_OUTPUT_BYTES {
+        return (text.to_string(), false);
+    }
+    let mut cut = MAX_OUTPUT_BYTES;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    (text[..cut].to_string(), true)
+}
+
+/// Applies the policy's output rule plus the DLP pipeline: one-way redaction
+/// of plain secrets/PII, then an obfuscation probe on the redacted text —
+/// anything suspicious left after redaction suppresses the whole stream.
+fn sanitize(policy: OutputPolicy, dlp: &DlpEngine, text: &str) -> String {
+    if policy == OutputPolicy::Suppress {
+        return SUPPRESSED_BY_POLICY.to_string();
+    }
+    let redacted = dlp.redact_permanent(text);
+    if dlp
+        .check_violations(&normalize_for_matching(&redacted))
+        .is_some()
+    {
+        return SUPPRESSED_BY_DLP.to_string();
+    }
+    redacted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DlpConfig;
+    use crate::security::DlpEngine;
+
+    fn engine() -> DlpEngine {
+        // The repo's shipped rules give the engine real secret patterns
+        // (sk_live_*, etc.) alongside the built-in PII detectors.
+        DlpEngine::build(&DlpConfig::default()).expect("engine with shipped rules")
+    }
+
+    fn action(exec: &[&str]) -> ActionDef {
+        ActionDef {
+            id: "test-action".into(),
+            description: "test".into(),
+            exec: exec.iter().map(|part| part.to_string()).collect(),
+            user: None,
+            timeout_secs: 10,
+            output: OutputPolicy::Redact,
+            env: vec![],
+        }
+    }
+
+    fn secret_broker(value: &'static str) -> SecretBroker {
+        struct Fixed(&'static str);
+        use async_trait::async_trait;
+        use open_guardian::secrets::{SecretBackend, SecretValue};
+        #[async_trait]
+        impl SecretBackend for Fixed {
+            fn scheme(&self) -> &'static str {
+                "test"
+            }
+            async fn resolve(
+                &self,
+                _reference: &open_guardian::secrets::SecretRef,
+            ) -> Result<SecretValue, open_guardian::secrets::SecretError> {
+                SecretValue::new(self.0.to_string())
+            }
+        }
+        let mut broker = SecretBroker::new();
+        broker.register(Fixed(value)).expect("register");
+        broker
+    }
+
+    fn env_binding(name: &str, reference: &str) -> super::super::policy::EnvBinding {
+        super::super::policy::EnvBinding {
+            name: name.into(),
+            reference: reference.parse().expect("ref"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plain_output_is_returned_verbatim() {
+        let result = execute_action(
+            &action(&["/bin/echo", "hello world"]),
+            &SecretBroker::new(),
+            &engine(),
+        )
+        .await;
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(result.stdout.trim(), "hello world");
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn secret_printed_by_the_command_is_redacted() {
+        // The secret comes from the env var the broker injected; the command
+        // echoes it back. The agent-visible stdout must not contain it.
+        let mut def = action(&["/bin/sh", "-c", "printf 'token=%s\\n' \"$DEPLOY_TOKEN\""]);
+        def.env = vec![env_binding(
+            "DEPLOY_TOKEN",
+            "{{secret:test://prod/deploy#token}}",
+        )];
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+
+        let result = execute_action(&def, &secret_broker(secret), &engine()).await;
+        assert_eq!(result.exit_code, Some(0));
+        assert!(
+            !result.stdout.contains(secret),
+            "stdout leaked the secret: {}",
+            result.stdout
+        );
+        assert!(result.stdout.contains("token="));
+    }
+
+    #[tokio::test]
+    async fn pii_in_output_is_redacted() {
+        let mut def = action(&["/bin/sh", "-c", "echo mail user@example.com done"]);
+        def.env = vec![];
+        let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
+        assert!(!result.stdout.contains("user@example.com"));
+        assert!(result.stdout.contains("<EMAIL>") || result.stdout.contains("EMAIL"));
+    }
+
+    #[tokio::test]
+    async fn obfuscated_secret_suppresses_the_whole_output() {
+        // Percent-encoded secret: plain redaction cannot rewrite it in place,
+        // so the probe must fail closed by suppressing everything.
+        let mut def = action(&[
+            "/bin/sh",
+            "-c",
+            "printf 'x %s y\\n' \"$(printf '%s' \"$DEPLOY_TOKEN\" | sed 's/Q/%51/g')\"",
+        ]);
+        def.env = vec![env_binding(
+            "DEPLOY_TOKEN",
+            "{{secret:test://prod/deploy#token}}",
+        )];
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+
+        let result = execute_action(&def, &secret_broker(secret), &engine()).await;
+        assert_eq!(result.stdout, SUPPRESSED_BY_DLP);
+    }
+
+    #[tokio::test]
+    async fn suppress_policy_never_returns_output() {
+        let mut def = action(&["/bin/echo", "innocuous"]);
+        def.output = OutputPolicy::Suppress;
+        let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
+        assert_eq!(result.stdout, SUPPRESSED_BY_POLICY);
+        assert!(result.suppressed);
+    }
+
+    #[tokio::test]
+    async fn unresolvable_secret_refuses_to_execute() {
+        use open_guardian::secrets::EnvironmentBackend;
+        let mut def = action(&["/bin/echo", "should-not-run"]);
+        def.env = vec![env_binding(
+            "DEPLOY_TOKEN",
+            "{{secret:env://DEFINITELY_MISSING_VAR_42}}",
+        )];
+
+        let mut broker = SecretBroker::new();
+        broker
+            .register(EnvironmentBackend)
+            .expect("register env backend");
+        let result = execute_action(&def, &broker, &engine()).await;
+        assert!(result.error.is_some());
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("DEFINITELY_MISSING_VAR_42"));
+        assert_eq!(
+            result.exit_code, None,
+            "nothing may execute when env resolution fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_the_process() {
+        let mut def = action(&["/bin/sleep", "30"]);
+        def.timeout_secs = 1;
+        let started = Instant::now();
+        let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
+        assert!(result.error.as_deref().unwrap().contains("timed out"));
+        assert!(started.elapsed().as_secs() < 10);
+    }
+
+    #[tokio::test]
+    async fn missing_binary_reports_error_without_panicking() {
+        let result = execute_action(
+            &action(&["/nonexistent/definitely-not-here"]),
+            &SecretBroker::new(),
+            &engine(),
+        )
+        .await;
+        assert!(result.error.is_some());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn elevated_action_invokes_sudo_non_interactively() {
+        // No sudoers rule exists for the test user, so sudo must fail fast
+        // (-n forbids the password prompt) — proving the argv shape.
+        let mut def = action(&["/bin/echo", "hi"]);
+        def.user = Some("root".into());
+        let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
+        assert_ne!(result.exit_code, Some(0));
+    }
+
+    #[tokio::test]
+    async fn oversized_output_is_truncated() {
+        let mut def = action(&["/bin/sh", "-c", "yes 0123456789abcdef | head -c 200000"]);
+        def.timeout_secs = 10;
+        let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
+        assert!(result.truncated);
+        assert!(result.stdout.len() <= MAX_OUTPUT_BYTES + 16);
+    }
+}

--- a/src/broker/execute.rs
+++ b/src/broker/execute.rs
@@ -210,14 +210,31 @@ mod tests {
         }
     }
 
+    /// Cross-platform argv: (unix argv, windows argv).
+    fn argv(unix: &[&str], windows: &[&str]) -> Vec<String> {
+        let parts = if cfg!(windows) { windows } else { unix };
+        parts.iter().map(|part| part.to_string()).collect()
+    }
+
+    fn action_argv(argv: Vec<String>) -> ActionDef {
+        ActionDef {
+            id: "test-action".into(),
+            description: "test".into(),
+            exec: argv,
+            user: None,
+            timeout_secs: 10,
+            output: OutputPolicy::Redact,
+            env: vec![],
+        }
+    }
+
     #[tokio::test]
     async fn plain_output_is_returned_verbatim() {
-        let result = execute_action(
-            &action(&["/bin/echo", "hello world"]),
-            &SecretBroker::new(),
-            &engine(),
-        )
-        .await;
+        let argv = argv(
+            &["/bin/echo", "hello world"],
+            &["C:/Windows/System32/cmd.exe", "/c", "echo", "hello world"],
+        );
+        let result = execute_action(&action_argv(argv), &SecretBroker::new(), &engine()).await;
         assert_eq!(result.exit_code, Some(0));
         assert_eq!(result.stdout.trim(), "hello world");
         assert!(result.error.is_none());
@@ -227,7 +244,15 @@ mod tests {
     async fn secret_printed_by_the_command_is_redacted() {
         // The secret comes from the env var the broker injected; the command
         // echoes it back. The agent-visible stdout must not contain it.
-        let mut def = action(&["/bin/sh", "-c", "printf 'token=%s\\n' \"$DEPLOY_TOKEN\""]);
+        let mut def = action_argv(argv(
+            &["/bin/sh", "-c", "printf 'token=%s\\n' \"$DEPLOY_TOKEN\""],
+            &[
+                "C:/Windows/System32/cmd.exe",
+                "/v:on",
+                "/c",
+                "echo token=!DEPLOY_TOKEN!",
+            ],
+        ));
         def.env = vec![env_binding(
             "DEPLOY_TOKEN",
             "{{secret:test://prod/deploy#token}}",
@@ -246,13 +271,24 @@ mod tests {
 
     #[tokio::test]
     async fn pii_in_output_is_redacted() {
-        let mut def = action(&["/bin/sh", "-c", "echo mail user@example.com done"]);
+        let mut def = action_argv(argv(
+            &["/bin/sh", "-c", "echo mail user@example.com done"],
+            &[
+                "C:/Windows/System32/cmd.exe",
+                "/c",
+                "echo",
+                "mail",
+                "user@example.com",
+                "done",
+            ],
+        ));
         def.env = vec![];
         let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
         assert!(!result.stdout.contains("user@example.com"));
         assert!(result.stdout.contains("<EMAIL>") || result.stdout.contains("EMAIL"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn obfuscated_secret_suppresses_the_whole_output() {
         // Percent-encoded secret: plain redaction cannot rewrite it in place,
@@ -274,7 +310,10 @@ mod tests {
 
     #[tokio::test]
     async fn suppress_policy_never_returns_output() {
-        let mut def = action(&["/bin/echo", "innocuous"]);
+        let mut def = action_argv(argv(
+            &["/bin/echo", "innocuous"],
+            &["C:/Windows/System32/cmd.exe", "/c", "echo", "innocuous"],
+        ));
         def.output = OutputPolicy::Suppress;
         let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
         assert_eq!(result.stdout, SUPPRESSED_BY_POLICY);
@@ -309,7 +348,17 @@ mod tests {
 
     #[tokio::test]
     async fn timeout_kills_the_process() {
-        let mut def = action(&["/bin/sleep", "30"]);
+        let mut def = action_argv(argv(
+            &["/bin/sleep", "30"],
+            &[
+                "C:/Windows/System32/cmd.exe",
+                "/c",
+                "ping",
+                "-n",
+                "30",
+                "127.0.0.1",
+            ],
+        ));
         def.timeout_secs = 1;
         let started = Instant::now();
         let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
@@ -339,6 +388,7 @@ mod tests {
         assert_ne!(result.exit_code, Some(0));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn oversized_output_is_truncated() {
         let mut def = action(&["/bin/sh", "-c", "yes 0123456789abcdef | head -c 200000"]);

--- a/src/broker/execute.rs
+++ b/src/broker/execute.rs
@@ -236,7 +236,7 @@ mod tests {
                 "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "-NoProfile",
                 "-Command",
-                "Write-Output hello world",
+                "Write-Output 'hello world'",
             ],
         );
         let result = execute_action(&action_argv(argv), &SecretBroker::new(), &engine()).await;
@@ -252,10 +252,10 @@ mod tests {
         let mut def = action_argv(argv(
             &["/bin/sh", "-c", "printf 'token=%s\\n' \"$DEPLOY_TOKEN\""],
             &[
-                "C:/Windows/System32/cmd.exe",
-                "/v:on",
-                "/c",
-                "echo token=!DEPLOY_TOKEN!",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-Command",
+                "Write-Output token=$env:DEPLOY_TOKEN",
             ],
         ));
         def.env = vec![env_binding(
@@ -279,12 +279,10 @@ mod tests {
         let mut def = action_argv(argv(
             &["/bin/sh", "-c", "echo mail user@example.com done"],
             &[
-                "C:/Windows/System32/cmd.exe",
-                "/c",
-                "echo",
-                "mail",
-                "user@example.com",
-                "done",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-Command",
+                "Write-Output 'mail user@example.com done'",
             ],
         ));
         def.env = vec![];
@@ -361,12 +359,10 @@ mod tests {
         let mut def = action_argv(argv(
             &["/bin/sleep", "30"],
             &[
-                "C:/Windows/System32/cmd.exe",
-                "/c",
-                "ping",
-                "-n",
-                "30",
-                "127.0.0.1",
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-Command",
+                "Start-Sleep -Seconds 30",
             ],
         ));
         def.timeout_secs = 1;

--- a/src/broker/execute.rs
+++ b/src/broker/execute.rs
@@ -232,7 +232,12 @@ mod tests {
     async fn plain_output_is_returned_verbatim() {
         let argv = argv(
             &["/bin/echo", "hello world"],
-            &["C:/Windows/System32/cmd.exe", "/c", "echo", "hello world"],
+            &[
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-Command",
+                "Write-Output hello world",
+            ],
         );
         let result = execute_action(&action_argv(argv), &SecretBroker::new(), &engine()).await;
         assert_eq!(result.exit_code, Some(0));
@@ -312,7 +317,12 @@ mod tests {
     async fn suppress_policy_never_returns_output() {
         let mut def = action_argv(argv(
             &["/bin/echo", "innocuous"],
-            &["C:/Windows/System32/cmd.exe", "/c", "echo", "innocuous"],
+            &[
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "-NoProfile",
+                "-Command",
+                "Write-Output innocuous",
+            ],
         ));
         def.output = OutputPolicy::Suppress;
         let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
@@ -380,12 +390,19 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn elevated_action_invokes_sudo_non_interactively() {
-        // No sudoers rule exists for the test user, so sudo must fail fast
-        // (-n forbids the password prompt) — proving the argv shape.
+        // A nonexistent target user fails under sudo no matter how sudoers is
+        // configured (CI runners ship NOPASSWD:ALL, so "sudo -u root echo"
+        // would succeed there). Success here would mean the sudo prefix is
+        // missing and the command ran directly.
         let mut def = action(&["/bin/echo", "hi"]);
-        def.user = Some("root".into());
+        def.user = Some("guardian-definitely-no-such-user".into());
         let result = execute_action(&def, &SecretBroker::new(), &engine()).await;
-        assert_ne!(result.exit_code, Some(0));
+        assert_ne!(
+            result.exit_code,
+            Some(0),
+            "command must go through sudo -n -u <user>"
+        );
+        assert!(result.error.is_none(), "spawn itself must succeed");
     }
 
     #[cfg(unix)]

--- a/src/broker/ipc.rs
+++ b/src/broker/ipc.rs
@@ -668,14 +668,24 @@ mod tests {
     }
 
     fn echo_action() -> ActionDef {
-        ActionDef {
-            id: "echo-token".into(),
-            description: "Echo the deploy token (DLP must redact it)".into(),
-            exec: vec![
+        let exec: Vec<String> = if cfg!(windows) {
+            vec![
+                "C:/Windows/System32/cmd.exe".into(),
+                "/v:on".into(),
+                "/c".into(),
+                "echo deploy used token=!DEPLOY_TOKEN!".into(),
+            ]
+        } else {
+            vec![
                 "/bin/sh".into(),
                 "-c".into(),
                 "printf 'deploy used token=%s\\n' \"$DEPLOY_TOKEN\"".into(),
-            ],
+            ]
+        };
+        ActionDef {
+            id: "echo-token".into(),
+            description: "Echo the deploy token (DLP must redact it)".into(),
+            exec,
             user: None,
             timeout_secs: 10,
             output: OutputPolicy::Redact,
@@ -759,6 +769,23 @@ mod tests {
 
         fn audit_content(&self) -> String {
             std::fs::read_to_string(&self.audit_path).expect("audit file")
+        }
+
+        /// The chain writer is asynchronous: poll until the file exists and
+        /// contains the needle (deterministic on every platform).
+        async fn wait_for_audit(&self, needle: &str) -> String {
+            for _ in 0..100 {
+                if let Ok(content) = std::fs::read_to_string(&self.audit_path) {
+                    if content.contains(needle) {
+                        return content;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            panic!(
+                "audit chain never contained {needle:?}: {:?}",
+                self.audit_content()
+            );
         }
     }
 
@@ -865,7 +892,7 @@ mod tests {
         );
 
         // The whole story is in the audit chain — and the chain verifies.
-        let audit = daemon.audit_content();
+        let audit = daemon.wait_for_audit("result_delivered").await;
         assert!(audit.contains("action_requested"));
         assert!(audit.contains("action_approve_rejected"));
         assert!(audit.contains("action_approved"));
@@ -912,7 +939,10 @@ mod tests {
         assert_eq!(status, 200);
         assert_eq!(body["status"], "denied");
 
-        assert!(daemon.audit_content().contains("action_denied"));
+        assert!(daemon
+            .wait_for_audit("action_denied")
+            .await
+            .contains("action_denied"));
     }
 
     #[tokio::test]

--- a/src/broker/ipc.rs
+++ b/src/broker/ipc.rs
@@ -854,7 +854,9 @@ mod tests {
         // Poll until completed; the secret injected into the child env must
         // never appear in the delivered result.
         let mut delivered = None;
-        for _ in 0..40 {
+        // PowerShell cold-start on CI Windows runners can take several
+        // seconds, so keep polling well past typical completion.
+        for _ in 0..100 {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let (status, body) = daemon
                 .post("/v1/status", AGENT_TOKEN, json!({"request_id": request_id}))

--- a/src/broker/ipc.rs
+++ b/src/broker/ipc.rs
@@ -670,10 +670,10 @@ mod tests {
     fn echo_action() -> ActionDef {
         let exec: Vec<String> = if cfg!(windows) {
             vec![
-                "C:/Windows/System32/cmd.exe".into(),
-                "/v:on".into(),
-                "/c".into(),
-                "echo deploy used token=!DEPLOY_TOKEN!".into(),
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe".into(),
+                "-NoProfile".into(),
+                "-Command".into(),
+                "Write-Output deploy-used-token=$env:DEPLOY_TOKEN".into(),
             ]
         } else {
             vec![

--- a/src/broker/ipc.rs
+++ b/src/broker/ipc.rs
@@ -1,0 +1,946 @@
+//! Broker daemon: loopback-only HTTP IPC with two bearer roles.
+//!
+//! - **Agent token** (used by the MCP server): list actions, create requests,
+//!   poll status. It can never see an approval code or approve anything.
+//! - **Admin token** (operator CLI): approve/deny/list. The only channel that
+//!   ever sees pending approval codes.
+//!
+//! `build_router` returns a plain axum `Router` so tests can drive the exact
+//! production daemon in-process, mirroring the egress proxy's `build_router`.
+
+use super::execute::execute_action;
+use super::policy::{ActionDef, Policy};
+use super::state::{constant_time_eq, ApproveError, RequestStore};
+use crate::security::{AuditChain, DlpEngine};
+use axum::{
+    extract::{Json, State as AxumState},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use chrono::Utc;
+use open_guardian::secrets::SecretBroker;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub const AGENT_DISCOVERY_FILE: &str = "guardian-broker.json";
+pub const ADMIN_DISCOVERY_FILE: &str = "guardian-broker-admin.json";
+
+#[derive(Clone)]
+pub struct DaemonOptions {
+    pub policy: Policy,
+    pub secret_broker: Arc<SecretBroker>,
+    pub dlp_engine: Arc<DlpEngine>,
+    pub audit: Arc<AuditChain>,
+    pub store: Arc<RequestStore>,
+    pub agent_token: String,
+    pub admin_token: String,
+}
+
+impl DaemonOptions {
+    /// Convenience constructor: generates both bearer tokens and the store
+    /// with the given TTLs.
+    pub fn new(
+        policy: Policy,
+        secret_broker: Arc<SecretBroker>,
+        dlp_engine: Arc<DlpEngine>,
+        audit: Arc<AuditChain>,
+        pending_ttl: Duration,
+        result_ttl: Duration,
+    ) -> Self {
+        Self {
+            policy,
+            secret_broker,
+            dlp_engine,
+            audit,
+            store: Arc::new(RequestStore::new(pending_ttl, result_ttl)),
+            agent_token: random_token(),
+            admin_token: random_token(),
+        }
+    }
+}
+
+fn random_token() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+pub struct Shared {
+    policy: Policy,
+    secret_broker: Arc<SecretBroker>,
+    dlp: Arc<DlpEngine>,
+    audit: Arc<AuditChain>,
+    store: Arc<RequestStore>,
+    agent_token: String,
+    admin_token: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    Agent,
+    Admin,
+}
+
+fn audit_event(name: &str, fields: Value) -> Value {
+    let mut event = fields;
+    if let Some(object) = event.as_object_mut() {
+        object.insert("timestamp".into(), Value::String(Utc::now().to_rfc3339()));
+        // Keep `event` adjacent to `timestamp` for readability; serde_json's
+        // key-sorted map makes the final layout deterministic anyway.
+        object.insert("event".into(), Value::String(name.to_string()));
+    }
+    event
+}
+
+fn role_of(headers: &HeaderMap, shared: &Shared) -> Option<Role> {
+    let header = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())?;
+    let token = header.strip_prefix("Bearer ")?;
+    if constant_time_eq(token.as_bytes(), shared.admin_token.as_bytes()) {
+        Some(Role::Admin)
+    } else if constant_time_eq(token.as_bytes(), shared.agent_token.as_bytes()) {
+        Some(Role::Agent)
+    } else {
+        None
+    }
+}
+
+fn unauthorized() -> axum::response::Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        "{\"error\":\"unauthorized\"}\n",
+    )
+        .into_response()
+}
+
+fn forbidden_agent() -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        "{\"error\":\"admin_channel_required\"}\n",
+    )
+        .into_response()
+}
+
+fn json_response(status: StatusCode, body: Value) -> axum::response::Response {
+    (
+        status,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&body).unwrap_or_default() + "\n",
+    )
+        .into_response()
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RequestIn {
+    action_id: String,
+    #[serde(default)]
+    reason: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ApproveIn {
+    request_id: String,
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    yes: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DenyIn {
+    request_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StatusIn {
+    request_id: String,
+}
+
+async fn list_actions(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    if role_of(&headers, &shared).is_none() {
+        return unauthorized();
+    }
+    let actions: Vec<Value> = shared
+        .policy
+        .actions
+        .iter()
+        .map(|action| {
+            json!({
+                "id": action.id,
+                "description": action.description,
+                "requires_elevation": action.user.is_some(),
+            })
+        })
+        .collect();
+    json_response(StatusCode::OK, json!({ "actions": actions }))
+}
+
+async fn create_request(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+    Json(input): Json<RequestIn>,
+) -> axum::response::Response {
+    if role_of(&headers, &shared).is_none() {
+        return unauthorized();
+    }
+    let Some(action) = shared.policy.action(&input.action_id) else {
+        return json_response(
+            StatusCode::NOT_FOUND,
+            json!({"error": "unknown_action", "action_id": input.action_id}),
+        );
+    };
+    if action.id != input.action_id {
+        return json_response(StatusCode::NOT_FOUND, json!({"error": "unknown_action"}));
+    }
+
+    // The agent-supplied reason is free text: sanitize before storing or
+    // echoing anywhere, exactly like any other inbound string.
+    let reason: String = shared
+        .dlp
+        .redact_permanent(&input.reason)
+        .chars()
+        .take(500)
+        .collect();
+
+    let created = shared.store.create(&action.id, &reason);
+    shared.audit.log(audit_event(
+        "action_requested",
+        json!({
+            "request_id": created.record.id,
+            "action_id": action.id,
+            "reason": reason,
+        }),
+    ));
+    notify_pending(&action.id, &created.record.id, &created.code, &reason);
+
+    json_response(
+        StatusCode::OK,
+        json!({
+            "request_id": created.record.id,
+            "status": "pending",
+            "expires_in_secs": created.pending_ttl.as_secs(),
+            "message": "awaiting operator approval (out-of-band)",
+        }),
+    )
+}
+
+fn notify_pending(action_id: &str, request_id: &str, code: &str, reason: &str) {
+    let reason_display = if reason.is_empty() {
+        "no reason given"
+    } else {
+        reason
+    };
+    let line = format!(
+        "BROKER pending: '{action_id}' ({reason_display}) — approve: open-guardian approve {request_id} --code {code}"
+    );
+    println!("{line}");
+    #[cfg(all(unix, feature = "desktop-notify"))]
+    {
+        let _ = notify_rust::Notification::new()
+            .summary("Open-Guardian: action requested")
+            .body(&line)
+            .show();
+    }
+}
+
+async fn approve_request(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+    Json(input): Json<ApproveIn>,
+) -> axum::response::Response {
+    if role_of(&headers, &shared) != Some(Role::Admin) {
+        return if role_of(&headers, &shared).is_some() {
+            forbidden_agent()
+        } else {
+            unauthorized()
+        };
+    }
+
+    let expected_code = shared.store.code_of(&input.request_id);
+    if !input.yes {
+        let Some(expected) = expected_code.as_ref() else {
+            return json_response(
+                StatusCode::CONFLICT,
+                json!({"error": "not_pending", "message": "request is not awaiting approval"}),
+            );
+        };
+        let provided = input.code.as_deref().unwrap_or("");
+        if !constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+            shared.audit.log(audit_event(
+                "action_approve_rejected",
+                json!({"request_id": input.request_id, "reason": "wrong_code"}),
+            ));
+            return json_response(
+                StatusCode::FORBIDDEN,
+                json!({"error": "wrong_code", "message": "run `open-guardian requests` to see the code"}),
+            );
+        }
+    }
+
+    match shared
+        .store
+        .approve(&input.request_id, expected_code.as_deref().unwrap_or(""))
+    {
+        Ok(approved) => {
+            shared.audit.log(audit_event(
+                "action_approved",
+                json!({
+                    "request_id": input.request_id,
+                    "action_id": approved.action_id,
+                    "code_bypassed": input.yes,
+                }),
+            ));
+
+            // Execute with the exact policy definition — never trusting any
+            // argv that arrived over IPC.
+            let action: ActionDef = shared
+                .policy
+                .action(&approved.action_id)
+                .expect("approved action exists in the signed policy")
+                .clone();
+            let execution_shared = shared.clone();
+            let request_id = input.request_id.clone();
+            tokio::spawn(async move {
+                let result = execute_action(
+                    &action,
+                    &execution_shared.secret_broker,
+                    &execution_shared.dlp,
+                )
+                .await;
+                execution_shared.audit.log(audit_event(
+                    "action_executed",
+                    json!({
+                        "request_id": request_id,
+                        "action_id": action.id,
+                        "exit_code": result.exit_code,
+                        "duration_ms": result.duration_ms,
+                        "truncated": result.truncated,
+                        "suppressed": result.suppressed,
+                        "error": result.error,
+                    }),
+                ));
+                execution_shared.store.complete(&request_id, result);
+            });
+
+            json_response(
+                StatusCode::OK,
+                json!({
+                    "request_id": input.request_id,
+                    "status": "executing",
+                    "message": "approved; execution started. Poll /v1/status for the one-time result.",
+                }),
+            )
+        }
+        Err(ApproveError::Unknown) => {
+            json_response(StatusCode::NOT_FOUND, json!({"error": "unknown_request"}))
+        }
+        Err(ApproveError::NotPending(why)) => json_response(
+            StatusCode::CONFLICT,
+            json!({"error": "not_pending", "message": why}),
+        ),
+        Err(ApproveError::WrongCode) => {
+            json_response(StatusCode::FORBIDDEN, json!({"error": "wrong_code"}))
+        }
+    }
+}
+
+async fn deny_request(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+    Json(input): Json<DenyIn>,
+) -> axum::response::Response {
+    if role_of(&headers, &shared) != Some(Role::Admin) {
+        return if role_of(&headers, &shared).is_some() {
+            forbidden_agent()
+        } else {
+            unauthorized()
+        };
+    }
+    match shared.store.deny(&input.request_id) {
+        Ok(()) => {
+            shared.audit.log(audit_event(
+                "action_denied",
+                json!({"request_id": input.request_id}),
+            ));
+            json_response(StatusCode::OK, json!({"status": "denied"}))
+        }
+        Err(ApproveError::Unknown) => {
+            json_response(StatusCode::NOT_FOUND, json!({"error": "unknown_request"}))
+        }
+        Err(ApproveError::NotPending(why)) => json_response(
+            StatusCode::CONFLICT,
+            json!({"error": "not_pending", "message": why}),
+        ),
+        Err(ApproveError::WrongCode) => unreachable!("deny never checks codes"),
+    }
+}
+
+async fn request_status(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+    Json(input): Json<StatusIn>,
+) -> axum::response::Response {
+    let Some(role) = role_of(&headers, &shared) else {
+        return unauthorized();
+    };
+    let Some(record) = shared.store.snapshot(&input.request_id) else {
+        return json_response(
+            StatusCode::NOT_FOUND,
+            json!({"error": "unknown_request", "status": "unknown"}),
+        );
+    };
+
+    let status = record.state.name();
+    let mut body = json!({
+        "request_id": record.id,
+        "action_id": record.action_id,
+        "reason": record.reason,
+        "status": status,
+        "created_at": record.created_at.to_rfc3339(),
+    });
+
+    // One-time result delivery (Vault single-reader semantics): whoever
+    // reads first consumes it; later readers see a tombstone note.
+    let delivered = shared.store.deliver(&input.request_id);
+    if let Some(result) = delivered {
+        if let Some(object) = body.as_object_mut() {
+            object.insert("result".into(), result.to_json());
+        }
+        shared.audit.log(audit_event(
+            "result_delivered",
+            json!({
+                "request_id": record.id,
+                "action_id": record.action_id,
+                "channel": if role == Role::Admin { "admin" } else { "agent" },
+            }),
+        ));
+    } else if status == "completed" {
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "note".into(),
+                Value::String("result already delivered once".into()),
+            );
+        }
+    }
+
+    json_response(StatusCode::OK, body)
+}
+
+async fn list_requests(
+    AxumState(shared): AxumState<Arc<Shared>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    if role_of(&headers, &shared) != Some(Role::Admin) {
+        return if role_of(&headers, &shared).is_some() {
+            forbidden_agent()
+        } else {
+            unauthorized()
+        };
+    }
+    let requests: Vec<Value> = shared
+        .store
+        .list()
+        .into_iter()
+        .map(|record| {
+            let mut entry = json!({
+                "id": record.id,
+                "action_id": record.action_id,
+                "reason": record.reason,
+                "status": record.state.name(),
+                "created_at": record.created_at.to_rfc3339(),
+            });
+            // The approval code is shown ONLY here and only while pending:
+            // this endpoint is reachable with the admin token alone.
+            if let super::state::RequestState::Pending { code, .. } = &record.state {
+                entry["code"] = Value::String(code.clone());
+            }
+            entry
+        })
+        .collect();
+    json_response(StatusCode::OK, json!({ "requests": requests }))
+}
+
+/// Assembles the daemon router. Serve it on 127.0.0.1 only.
+pub fn build_router(options: DaemonOptions) -> Router {
+    let DaemonOptions {
+        policy,
+        secret_broker,
+        dlp_engine,
+        audit,
+        store,
+        agent_token,
+        admin_token,
+    } = options;
+
+    let shared = Arc::new(Shared {
+        policy,
+        secret_broker,
+        dlp: dlp_engine,
+        audit,
+        store,
+        agent_token,
+        admin_token,
+    });
+
+    Router::new()
+        .route("/v1/actions", post(list_actions))
+        .route("/v1/request", post(create_request))
+        .route("/v1/status", post(request_status))
+        .route("/v1/approve", post(approve_request))
+        .route("/v1/deny", post(deny_request))
+        .route("/v1/requests", post(list_requests))
+        .with_state(shared)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Discovery files
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Directory holding the discovery files (addr + bearer tokens).
+pub fn runtime_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("GUARDIAN_BROKER_RUNTIME_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        return PathBuf::from(dir);
+    }
+    std::env::temp_dir().join("guardian-broker")
+}
+
+fn write_discovery(path: &std::path::Path, addr: SocketAddr, token: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| anyhow::anyhow!("cannot create {}: {error}", parent.display()))?;
+    }
+    let body = json!({"addr": addr.to_string(), "token": token});
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|error| anyhow::anyhow!("cannot write {}: {error}", path.display()))?;
+        file.write_all((serde_json::to_string_pretty(&body).unwrap() + "\n").as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(path, serde_json::to_string_pretty(&body).unwrap() + "\n")?;
+    Ok(())
+}
+
+/// Reads a discovery file written by a running daemon.
+pub fn read_discovery(file: &str) -> anyhow::Result<(String, String)> {
+    let path = runtime_dir().join(file);
+    let content = std::fs::read_to_string(&path).map_err(|error| {
+        anyhow::anyhow!(
+            "cannot read {} (is the broker running?): {error}",
+            path.display()
+        )
+    })?;
+    let value: Value = serde_json::from_str(&content)
+        .map_err(|error| anyhow::anyhow!("malformed discovery file {}: {error}", path.display()))?;
+    let addr = value
+        .get("addr")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("discovery file missing addr"))?
+        .to_string();
+    let token = value
+        .get("token")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("discovery file missing token"))?
+        .to_string();
+    Ok((addr, token))
+}
+
+/// Binds loopback, writes both discovery files, spawns the sweeper, and
+/// serves until the shutdown token fires. Returns the bound address.
+pub async fn start(
+    options: DaemonOptions,
+    shutdown_token: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<SocketAddr> {
+    options.audit.log(audit_event(
+        "policy_loaded",
+        json!({
+            "fingerprint": options.policy.fingerprint,
+            "actions": options.policy.actions.len(),
+        }),
+    ));
+
+    let agent_token = options.agent_token.clone();
+    let admin_token = options.admin_token.clone();
+    let store = options.store.clone();
+    let audit = options.audit.clone();
+    let action_count = options.policy.actions.len();
+    let router = build_router(options);
+
+    // Loopback only, ephemeral port: never exposed to the network.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    let dir = runtime_dir();
+    write_discovery(&dir.join(AGENT_DISCOVERY_FILE), addr, &agent_token)?;
+    write_discovery(&dir.join(ADMIN_DISCOVERY_FILE), addr, &admin_token)?;
+
+    audit.log(audit_event(
+        "broker_started",
+        json!({"addr": addr.to_string(), "actions": action_count}),
+    ));
+
+    // Sweeper: expire stale pending requests and drop consumed results.
+    let sweeper_audit = audit.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(5));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            for request_id in store.sweep() {
+                sweeper_audit.log(audit_event(
+                    "action_expired",
+                    json!({"request_id": request_id}),
+                ));
+            }
+        }
+    });
+
+    println!(
+        "BROKER listening on {addr} ({action_count} actions). Agent file: {} | Admin file: {}",
+        dir.join(AGENT_DISCOVERY_FILE).display(),
+        dir.join(ADMIN_DISCOVERY_FILE).display()
+    );
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            shutdown_token.cancelled().await;
+            println!("BROKER shutting down.");
+        })
+        .await?;
+
+    audit.log(audit_event("broker_stopped", json!({})));
+    Ok(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::policy::{EnvBinding, OutputPolicy};
+    use crate::config::DlpConfig;
+    use crate::security::DlpEngine;
+    use async_trait::async_trait;
+    use open_guardian::secrets::{SecretBackend, SecretBroker, SecretRef, SecretValue};
+
+    const AGENT_TOKEN: &str = "agent-test-token";
+    const ADMIN_TOKEN: &str = "admin-test-token";
+    const SECRET: &str = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+
+    struct FixedBackend;
+
+    #[async_trait]
+    impl SecretBackend for FixedBackend {
+        fn scheme(&self) -> &'static str {
+            "test"
+        }
+        async fn resolve(
+            &self,
+            _reference: &SecretRef,
+        ) -> Result<SecretValue, open_guardian::secrets::SecretError> {
+            SecretValue::new(SECRET.to_string())
+        }
+    }
+
+    fn echo_action() -> ActionDef {
+        ActionDef {
+            id: "echo-token".into(),
+            description: "Echo the deploy token (DLP must redact it)".into(),
+            exec: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf 'deploy used token=%s\\n' \"$DEPLOY_TOKEN\"".into(),
+            ],
+            user: None,
+            timeout_secs: 10,
+            output: OutputPolicy::Redact,
+            env: vec![EnvBinding {
+                name: "DEPLOY_TOKEN".into(),
+                reference: "{{secret:test://prod/deploy#token}}".parse().expect("ref"),
+            }],
+        }
+    }
+
+    struct TestDaemon {
+        base: String,
+        audit_path: std::path::PathBuf,
+        _server: tokio::task::JoinHandle<()>,
+        _writer: tokio::task::JoinHandle<()>,
+    }
+
+    impl TestDaemon {
+        async fn start() -> Self {
+            let policy = Policy {
+                actions: vec![echo_action()],
+                fingerprint: "testfingerprint".into(),
+            };
+            let mut secret_broker = SecretBroker::new();
+            secret_broker.register(FixedBackend).expect("register");
+            let dlp = DlpEngine::build(&DlpConfig::default()).expect("dlp engine");
+
+            // Unique per daemon instance: tests run concurrently in-process.
+            static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let instance = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let audit_path = std::env::temp_dir().join(format!(
+                "guardian-broker-ipc-{}-{instance}.jsonl",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&audit_path);
+            let (audit, writer) = AuditChain::open(&audit_path).expect("audit chain");
+
+            let options = DaemonOptions {
+                policy,
+                secret_broker: Arc::new(secret_broker),
+                dlp_engine: Arc::new(dlp),
+                audit,
+                store: Arc::new(RequestStore::new(
+                    Duration::from_secs(120),
+                    Duration::from_secs(300),
+                )),
+                agent_token: AGENT_TOKEN.into(),
+                admin_token: ADMIN_TOKEN.into(),
+            };
+            let router = build_router(options);
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("addr");
+            let server = tokio::spawn(async move {
+                axum::serve(listener, router).await.expect("daemon serve");
+            });
+
+            Self {
+                base: format!("http://{addr}"),
+                audit_path,
+                _server: server,
+                _writer: writer,
+            }
+        }
+
+        async fn post(&self, path: &str, token: &str, body: Value) -> (u16, Value) {
+            let client = reqwest::Client::new();
+            let response = client
+                .post(format!("{}{path}", self.base))
+                .bearer_auth(token)
+                .json(&body)
+                .send()
+                .await
+                .expect("request");
+            let status = response.status().as_u16();
+            let payload = response.json().await.expect("json");
+            (status, payload)
+        }
+
+        fn audit_content(&self) -> String {
+            std::fs::read_to_string(&self.audit_path).expect("audit file")
+        }
+    }
+
+    #[tokio::test]
+    async fn full_lifecycle_approve_execute_and_one_time_delivery() {
+        let daemon = TestDaemon::start().await;
+
+        // Agent requests the action with a reason containing PII: the stored
+        // reason must come back redacted.
+        let (status, body) = daemon
+            .post(
+                "/v1/request",
+                AGENT_TOKEN,
+                json!({"action_id": "echo-token", "reason": "deploy for bob@example.com"}),
+            )
+            .await;
+        assert_eq!(status, 200, "body: {body}");
+        let request_id = body["request_id"].as_str().expect("id").to_string();
+        assert_eq!(body["status"], "pending");
+        assert!(
+            !body.to_string().contains("example.com"),
+            "agent response echoed unredacted reason: {body}"
+        );
+
+        // Agent cannot approve, even with the right code (unknown to it).
+        let (status, body) = daemon
+            .post(
+                "/v1/approve",
+                AGENT_TOKEN,
+                json!({"request_id": request_id, "code": "whatever"}),
+            )
+            .await;
+        assert_eq!(status, 403, "agent channel must not approve: {body}");
+        assert_eq!(body["error"], "admin_channel_required");
+
+        // Admin listing shows the code.
+        let (status, body) = daemon.post("/v1/requests", ADMIN_TOKEN, Value::Null).await;
+        assert_eq!(status, 200);
+        let listing = body["requests"].as_array().expect("requests");
+        let code = listing[0]["code"]
+            .as_str()
+            .expect("pending code")
+            .to_string();
+        assert_eq!(code.len(), 6);
+
+        // Wrong code is rejected and audited.
+        let (status, _) = daemon
+            .post(
+                "/v1/approve",
+                ADMIN_TOKEN,
+                json!({"request_id": request_id, "code": "wrong1"}),
+            )
+            .await;
+        assert_eq!(status, 403);
+
+        // Correct code approves; execution runs.
+        let (status, body) = daemon
+            .post(
+                "/v1/approve",
+                ADMIN_TOKEN,
+                json!({"request_id": request_id, "code": code}),
+            )
+            .await;
+        assert_eq!(status, 200, "body: {body}");
+
+        // Poll until completed; the secret injected into the child env must
+        // never appear in the delivered result.
+        let mut delivered = None;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let (status, body) = daemon
+                .post("/v1/status", AGENT_TOKEN, json!({"request_id": request_id}))
+                .await;
+            assert_eq!(status, 200);
+            if body["status"] == "completed" {
+                if body.get("result").is_some() {
+                    delivered = Some(body);
+                    break;
+                }
+                delivered = Some(body); // already consumed elsewhere
+                break;
+            }
+        }
+        let delivered = delivered.expect("request completed");
+        let result = delivered.get("result").expect("one-time result");
+        assert!(
+            !result.to_string().contains(SECRET),
+            "result leaked the secret: {result}"
+        );
+        assert!(result["stdout"]
+            .as_str()
+            .expect("stdout")
+            .contains("token="));
+
+        // Second poll: no result again (single delivery).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let (status, body) = daemon
+            .post("/v1/status", AGENT_TOKEN, json!({"request_id": request_id}))
+            .await;
+        assert_eq!(status, 200);
+        assert!(
+            body.get("result").is_none(),
+            "result delivered twice: {body}"
+        );
+
+        // The whole story is in the audit chain — and the chain verifies.
+        let audit = daemon.audit_content();
+        assert!(audit.contains("action_requested"));
+        assert!(audit.contains("action_approve_rejected"));
+        assert!(audit.contains("action_approved"));
+        assert!(audit.contains("action_executed"));
+        assert!(audit.contains("result_delivered"));
+        assert!(!audit.contains(SECRET), "audit leaked the secret");
+        assert!(!audit.contains("example.com"), "audit leaked reason PII");
+        let report =
+            crate::security::verify_audit_chain(&daemon.audit_path).expect("chain verifies");
+        assert!(report.lines >= 5);
+    }
+
+    #[tokio::test]
+    async fn unknown_action_is_rejected_and_denial_is_audited() {
+        let daemon = TestDaemon::start().await;
+
+        let (status, _) = daemon
+            .post(
+                "/v1/request",
+                AGENT_TOKEN,
+                json!({"action_id": "definitely-not-in-policy", "reason": "x"}),
+            )
+            .await;
+        assert_eq!(status, 404);
+
+        // Valid request, then denied by the operator.
+        let (_, body) = daemon
+            .post(
+                "/v1/request",
+                AGENT_TOKEN,
+                json!({"action_id": "echo-token", "reason": "test"}),
+            )
+            .await;
+        let request_id = body["request_id"].as_str().expect("id").to_string();
+
+        let (status, body) = daemon
+            .post("/v1/deny", ADMIN_TOKEN, json!({"request_id": request_id}))
+            .await;
+        assert_eq!(status, 200, "{body}");
+
+        let (status, body) = daemon
+            .post("/v1/status", AGENT_TOKEN, json!({"request_id": request_id}))
+            .await;
+        assert_eq!(status, 200);
+        assert_eq!(body["status"], "denied");
+
+        assert!(daemon.audit_content().contains("action_denied"));
+    }
+
+    #[tokio::test]
+    async fn bad_tokens_and_agent_listing_are_rejected() {
+        let daemon = TestDaemon::start().await;
+
+        let (status, _) = daemon
+            .post(
+                "/v1/request",
+                "wrong-token",
+                json!({"action_id": "echo-token", "reason": "x"}),
+            )
+            .await;
+        assert_eq!(status, 401);
+
+        // The agent channel must never see approval codes.
+        let (status, body) = daemon.post("/v1/requests", AGENT_TOKEN, Value::Null).await;
+        assert_eq!(status, 403, "{body}");
+    }
+
+    #[tokio::test]
+    async fn list_actions_shows_policy_surface() {
+        let daemon = TestDaemon::start().await;
+        let (status, body) = daemon.post("/v1/actions", AGENT_TOKEN, Value::Null).await;
+        assert_eq!(status, 200);
+        let actions = body["actions"].as_array().expect("actions");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0]["id"], "echo-token");
+        assert_eq!(actions[0]["requires_elevation"], false);
+    }
+}

--- a/src/broker/mcp.rs
+++ b/src/broker/mcp.rs
@@ -1,0 +1,195 @@
+//! MCP stdio surface for AI agent harnesses (Claude Code, Cursor, Goose, …).
+//!
+//! Three tools, all agent-channel only: the MCP client can list actions,
+//! request one, and poll its status. Approval codes and admin operations
+//! never cross this boundary by construction.
+
+use super::client::{BrokerClient, StatusReport};
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::model::ErrorCode;
+use rmcp::tool;
+use rmcp::tool_handler;
+use rmcp::tool_router;
+use rmcp::transport::stdio;
+use rmcp::ServerHandler;
+use rmcp::ServiceExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct GuardianTools {
+    client: BrokerClient,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct RequestActionParams {
+    /// Action id as returned by guardian_list_actions.
+    action_id: String,
+    /// Short human-readable justification for the operator.
+    #[serde(default)]
+    reason: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct RequestCreatedOut {
+    request_id: String,
+    status: String,
+    expires_in_secs: Option<u64>,
+    message: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct StatusParams {
+    request_id: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct StatusOut {
+    request_id: String,
+    action_id: String,
+    status: String,
+    /// Present exactly once, on the first successful poll after completion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct ActionsOut {
+    actions: Vec<ActionSummaryOut>,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct ActionSummaryOut {
+    id: String,
+    description: String,
+    requires_elevation: bool,
+}
+
+fn internal(message: impl Into<String>) -> rmcp::ErrorData {
+    rmcp::ErrorData::new(
+        ErrorCode::INTERNAL_ERROR,
+        format!("guardian broker: {}", message.into()),
+        None,
+    )
+}
+
+fn invalid(message: impl Into<String>) -> rmcp::ErrorData {
+    rmcp::ErrorData::new(
+        ErrorCode::INVALID_PARAMS,
+        format!("guardian broker: {}", message.into()),
+        None,
+    )
+}
+
+#[tool_router]
+impl GuardianTools {
+    pub fn new(client: BrokerClient) -> Self {
+        Self { client }
+    }
+
+    #[tool(
+        name = "guardian_list_actions",
+        description = "List the privileged actions the operator's signed policy allows this agent to request."
+    )]
+    async fn list_actions(&self) -> Result<Json<ActionsOut>, rmcp::ErrorData> {
+        let actions = self
+            .client
+            .list_actions()
+            .await
+            .map_err(|error| internal(error.to_string()))?;
+        Ok(Json(ActionsOut {
+            actions: actions
+                .into_iter()
+                .map(|action| ActionSummaryOut {
+                    id: action.id,
+                    description: action.description,
+                    requires_elevation: action.requires_elevation,
+                })
+                .collect(),
+        }))
+    }
+
+    #[tool(
+        name = "guardian_request_action",
+        description = "Request a privileged action. A human operator must approve it out-of-band before it executes. Poll guardian_request_status afterwards."
+    )]
+    async fn request_action(
+        &self,
+        Parameters(params): Parameters<RequestActionParams>,
+    ) -> Result<Json<RequestCreatedOut>, rmcp::ErrorData> {
+        let created = self
+            .client
+            .request_action(&params.action_id, &params.reason)
+            .await
+            .map_err(|error| {
+                // Unknown actions are client mistakes, not broker failures.
+                if error.to_string().contains("unknown_action") {
+                    invalid(error.to_string())
+                } else {
+                    internal(error.to_string())
+                }
+            })?;
+        Ok(Json(RequestCreatedOut {
+            request_id: created.request_id,
+            status: created.status,
+            expires_in_secs: created.expires_in_secs,
+            message: created.message,
+        }))
+    }
+
+    #[tool(
+        name = "guardian_request_status",
+        description = "Poll an action request. On the first poll after execution finishes, includes the (DLP-sanitized) result; it is delivered exactly once."
+    )]
+    async fn request_status(
+        &self,
+        Parameters(params): Parameters<StatusParams>,
+    ) -> Result<Json<StatusOut>, rmcp::ErrorData> {
+        let status: StatusReport =
+            self.client
+                .status(&params.request_id)
+                .await
+                .map_err(|error| {
+                    if error.to_string().contains("unknown_request") {
+                        invalid(error.to_string())
+                    } else {
+                        internal(error.to_string())
+                    }
+                })?;
+        Ok(Json(StatusOut {
+            request_id: status.request_id,
+            action_id: status.action_id,
+            status: status.status,
+            result: status.result,
+            note: status.note,
+        }))
+    }
+}
+
+#[tool_handler(
+    name = "open-guardian",
+    version = "0.5.0",
+    instructions = "Request privileged actions behind the operator's signed policy. Approval is always out-of-band; poll guardian_request_status for results."
+)]
+impl ServerHandler for GuardianTools {}
+
+/// Serves the MCP tools over stdio until the client disconnects.
+pub async fn run_stdio() -> anyhow::Result<()> {
+    let client = BrokerClient::agent().map_err(|error| {
+        anyhow::anyhow!(
+            "cannot reach the broker daemon: {error} (start it with `open-guardian broker start`)"
+        )
+    })?;
+    let service = GuardianTools::new(client)
+        .serve(stdio())
+        .await
+        .map_err(|error| anyhow::anyhow!("MCP stdio transport failed: {error}"))?;
+    service
+        .waiting()
+        .await
+        .map_err(|error| anyhow::anyhow!("MCP service terminated: {error}"))?;
+    Ok(())
+}

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -1,0 +1,86 @@
+//! Action Broker (v0.5): privileged actions for AI agents behind signed
+//! policies, out-of-band human approval, hash-chained audit, and output DLP.
+//!
+//! The daemon (`open-guardian broker start`) is the single authority: it loads
+//! the signed policy, owns the request state machine, executes commands
+//! without a shell, resolves secrets only inside the child's environment, and
+//! scans captured output with the same DLP engine the egress proxy uses.
+//!
+//! Two frontends talk to it over loopback HTTP with separate bearer tokens:
+//! the MCP stdio server (agent channel: request + status only) and the
+//! operator CLI (approve/deny/list — the only channel that sees approval
+//! codes).
+
+pub mod client;
+pub mod execute;
+pub mod ipc;
+pub mod policy;
+pub mod state;
+
+#[cfg(feature = "mcp")]
+pub mod mcp;
+
+use crate::config;
+use crate::security::{AuditChain, DlpEngine};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Loads config, verifies the signed policy, wires DLP + secrets + audit,
+/// and serves the daemon until shutdown. Every failure is fatal by design.
+pub async fn run_daemon(shutdown_token: tokio_util::sync::CancellationToken) -> anyhow::Result<()> {
+    let file_config = config::load_config()?;
+    let broker_cfg = file_config.broker.clone().unwrap_or_default();
+
+    let policy_path =
+        config::resolve_resource_path(broker_cfg.policy.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("[broker] policy = \"broker/policy.toml\" is required in guardian.toml")
+        })?);
+    let public_key_path =
+        config::resolve_resource_path(broker_cfg.public_key.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "[broker] public_key = \"broker/policy.pub\" is required in guardian.toml"
+            )
+        })?);
+    let policy = policy::load_signed_policy(&policy_path, &public_key_path)?;
+
+    // The broker runs privileged commands; unlike the proxy it refuses to
+    // start if the DLP rules are missing rather than continuing with the
+    // built-in PII detectors alone.
+    let dlp_config = file_config
+        .security
+        .as_ref()
+        .and_then(|security| security.dlp.clone())
+        .unwrap_or_default();
+    if let Some(first) = dlp_config.rules_files.first() {
+        let rules_path = config::resolve_resource_path(first);
+        if !rules_path.exists() {
+            anyhow::bail!(
+                "broker refuses to start: DLP rules file {} not found",
+                rules_path.display()
+            );
+        }
+    }
+    let dlp_engine =
+        DlpEngine::build(&dlp_config).map_err(|error| anyhow::anyhow!("DLP engine: {error}"))?;
+
+    let secret_broker =
+        Arc::new(crate::server::assemble_secret_broker(file_config.vault.as_ref()).await?);
+
+    let audit_path = broker_cfg
+        .audit_log_path
+        .clone()
+        .unwrap_or_else(|| "guardian_broker_audit.jsonl".to_string());
+    let (audit, _writer) = AuditChain::open(config::resolve_resource_path(&audit_path))?;
+
+    let options = ipc::DaemonOptions::new(
+        policy,
+        secret_broker,
+        Arc::new(dlp_engine),
+        audit,
+        Duration::from_secs(broker_cfg.pending_ttl_secs.unwrap_or(120)),
+        Duration::from_secs(broker_cfg.result_ttl_secs.unwrap_or(300)),
+    );
+
+    ipc::start(options, shutdown_token).await?;
+    Ok(())
+}

--- a/src/broker/policy.rs
+++ b/src/broker/policy.rs
@@ -393,25 +393,35 @@ pub fn sudoers_lines(policy: &Policy, invoking_user: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
-    const MINIMAL_POLICY: &str = r#"
+    fn minimal_policy() -> String {
+        // Absolute programs so validation passes on every platform.
+        let (echo, systemctl) = if cfg!(windows) {
+            ("C:/Windows/System32/cmd.exe", "C:/Windows/System32/sc.exe")
+        } else {
+            ("/bin/echo", "/usr/bin/systemctl")
+        };
+        format!(
+            r#"
 version = 1
 
 [[action]]
 id = "echo-hello"
 description = "Echo hello"
-exec = ["/bin/echo", "hello"]
+exec = ["{echo}", "hello"]
 
 [[action]]
 id = "restart-nginx"
 description = "Restart nginx"
-exec = ["/usr/bin/systemctl", "restart", "nginx"]
+exec = ["{systemctl}", "restart", "nginx"]
 user = "root"
 timeout_secs = 30
 
 [[action.env]]
 name = "DEPLOY_TOKEN"
-reference = "{{secret:env://DEPLOY_TOKEN}}"
-"#;
+reference = "{{{{secret:env://DEPLOY_TOKEN}}}}"
+"#
+        )
+    }
 
     struct TempDir(std::path::PathBuf);
 
@@ -439,7 +449,7 @@ reference = "{{secret:env://DEPLOY_TOKEN}}"
         let dir = TempDir::new(tag);
         let policy_path = dir.path("policy.toml");
         let key_path = dir.path("policy.key");
-        std::fs::write(&policy_path, MINIMAL_POLICY).expect("write policy");
+        std::fs::write(&policy_path, minimal_policy()).expect("write policy");
         keygen(&key_path).expect("keygen");
         sign_policy(&policy_path, &key_path).expect("sign");
         (dir, policy_path, key_path.with_extension("pub"))
@@ -479,7 +489,7 @@ reference = "{{secret:env://DEPLOY_TOKEN}}"
         let dir = TempDir::new("nosig");
         let policy_path = dir.path("policy.toml");
         let key_path = dir.path("policy.key");
-        std::fs::write(&policy_path, MINIMAL_POLICY).expect("write");
+        std::fs::write(&policy_path, minimal_policy()).expect("write");
         keygen(&key_path).expect("keygen");
         // Never signed.
 
@@ -519,6 +529,7 @@ reference = "{{secret:env://DEPLOY_TOKEN}}"
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn sudoers_lines_are_exact_and_only_for_elevated_actions() {
         let (_dir, policy_path, pub_path) = signed_policy_dir("sudoers");

--- a/src/broker/policy.rs
+++ b/src/broker/policy.rs
@@ -1,0 +1,541 @@
+//! Signed action policies for the broker.
+//!
+//! A policy is a strict TOML file listing exactly which commands an agent may
+//! request. It only takes effect with a valid detached ed25519 signature
+//! (`<policy>.sig`) made by the key whose public half is pinned next to the
+//! daemon. Verification is fail-closed: missing signature, wrong key, or one
+//! flipped byte in the policy refuses to load.
+//!
+//! Signature file format (two lines):
+//!
+//! ```text
+//! untrusted comment: open-guardian policy signature key=<key id>
+//! <128 hex chars: ed25519 signature over the exact policy file bytes>
+//! ```
+
+use anyhow::{Context, Result};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use open_guardian::secrets::SecretRef;
+use rand::{rngs::OsRng, RngCore};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::path::Path;
+
+pub const POLICY_VERSION: u32 = 1;
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// What the broker may do with a command's captured output.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputPolicy {
+    /// Run the output through the DLP engine (default): secrets and PII are
+    /// replaced with one-way placeholders before anyone sees them.
+    #[default]
+    Redact,
+    /// Never return output at all, regardless of content.
+    Suppress,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+struct RawPolicy {
+    version: u32,
+    #[serde(rename = "action")]
+    actions: Vec<RawAction>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+struct RawAction {
+    id: String,
+    description: String,
+    /// Literal argv. Never interpreted by a shell.
+    exec: Vec<String>,
+    /// sudo target user (Unix). `None` runs as the daemon's own user.
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default = "default_timeout")]
+    timeout_secs: u64,
+    #[serde(default)]
+    output: OutputPolicy,
+    #[serde(default)]
+    env: Vec<RawEnv>,
+}
+
+fn default_timeout() -> u64 {
+    DEFAULT_TIMEOUT_SECS
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+struct RawEnv {
+    name: String,
+    reference: SecretRef,
+}
+
+/// One allowlisted action, validated.
+#[derive(Debug, Clone)]
+pub struct ActionDef {
+    pub id: String,
+    pub description: String,
+    pub exec: Vec<String>,
+    pub user: Option<String>,
+    pub timeout_secs: u64,
+    pub output: OutputPolicy,
+    pub env: Vec<EnvBinding>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnvBinding {
+    pub name: String,
+    pub reference: SecretRef,
+}
+
+/// A fully verified policy.
+#[derive(Debug, Clone)]
+pub struct Policy {
+    pub actions: Vec<ActionDef>,
+    /// sha256 of the exact signed bytes, for audit records.
+    pub fingerprint: String,
+}
+
+impl Policy {
+    pub fn action(&self, id: &str) -> Option<&ActionDef> {
+        self.actions.iter().find(|action| action.id == id)
+    }
+}
+
+fn parse_and_validate(bytes: &str) -> Result<Vec<ActionDef>> {
+    let raw: RawPolicy = toml::from_str(bytes).context("invalid policy TOML")?;
+    if raw.version != POLICY_VERSION {
+        anyhow::bail!(
+            "unsupported policy version {} (expected {POLICY_VERSION})",
+            raw.version
+        );
+    }
+
+    let mut seen_ids = HashSet::new();
+    for action in &raw.actions {
+        if action.id.is_empty()
+            || !action
+                .id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            anyhow::bail!(
+                "action id {:?} must be non-empty lowercase kebab-case",
+                action.id
+            );
+        }
+        if !seen_ids.insert(action.id.clone()) {
+            anyhow::bail!("duplicate action id {:?}", action.id);
+        }
+        if action.description.trim().is_empty() {
+            anyhow::bail!("action {:?} needs a description", action.id);
+        }
+        if action.exec.is_empty() || action.exec.iter().any(|part| part.is_empty()) {
+            anyhow::bail!(
+                "action {:?} exec must be a non-empty argv with no empty parts",
+                action.id
+            );
+        }
+        let program = &action.exec[0];
+        if !Path::new(program).is_absolute() {
+            anyhow::bail!(
+                "action {:?} exec program must be an absolute path, got {:?}",
+                action.id,
+                program
+            );
+        }
+        if let Some(user) = &action.user {
+            if user.is_empty()
+                || !user
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+            {
+                anyhow::bail!(
+                    "action {:?} user {:?} is not a plausible unix user name",
+                    action.id,
+                    user
+                );
+            }
+        }
+        if action.timeout_secs == 0 || action.timeout_secs > 600 {
+            anyhow::bail!(
+                "action {:?} timeout_secs must be between 1 and 600",
+                action.id
+            );
+        }
+        for binding in &action.env {
+            if !is_valid_env_name(&binding.name) {
+                anyhow::bail!(
+                    "action {:?} env name {:?} is not a valid variable name",
+                    action.id,
+                    binding.name
+                );
+            }
+        }
+    }
+
+    Ok(raw
+        .actions
+        .into_iter()
+        .map(|action| ActionDef {
+            id: action.id,
+            description: action.description,
+            exec: action.exec,
+            user: action.user,
+            timeout_secs: action.timeout_secs,
+            output: action.output,
+            env: action
+                .env
+                .into_iter()
+                .map(|binding| EnvBinding {
+                    name: binding.name,
+                    reference: binding.reference,
+                })
+                .collect(),
+        })
+        .collect())
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('_' | 'A'..='Z' | 'a'..='z'))
+        && chars.all(|c| matches!(c, '_' | 'A'..='Z' | 'a'..='z' | '0'..='9'))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Keys and signatures
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
+    if path.exists() {
+        anyhow::bail!("refusing to overwrite existing key {}", path.display());
+    }
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("cannot create {}", path.display()))?;
+        file.write_all(bytes)?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(path, bytes).with_context(|| format!("cannot create {}", path.display()))?;
+    Ok(())
+}
+
+/// Short, stable identifier for a public key: first 16 hex of sha256.
+pub fn key_id(verifying_key: &VerifyingKey) -> String {
+    let digest = Sha256::digest(verifying_key.as_bytes());
+    hex::encode(&digest[..8])
+}
+
+/// Generates an ed25519 keypair: `secret_path` (0600, hex seed) and
+/// `secret_path.pub` (hex public key).
+pub fn keygen(secret_path: &Path) -> Result<VerifyingKey> {
+    // Seed from the process CSPRNG, then derive the key pair deterministically
+    // (avoids pulling ed25519-dalek's rand_core 0.10 alongside our rand 0.8).
+    let mut seed = [0u8; 32];
+    OsRng.fill_bytes(&mut seed);
+    let signing_key = SigningKey::from_bytes(&seed);
+    write_private(
+        secret_path,
+        format!("{}\n", hex::encode(signing_key.as_bytes())).as_bytes(),
+    )?;
+    let public_path = secret_path.with_extension("pub");
+    if public_path == secret_path {
+        anyhow::bail!("key path must have an extension for the .pub sibling");
+    }
+    std::fs::write(
+        &public_path,
+        format!("{}\n", hex::encode(signing_key.verifying_key().as_bytes())).as_bytes(),
+    )
+    .with_context(|| format!("cannot create {}", public_path.display()))?;
+    Ok(signing_key.verifying_key())
+}
+
+fn read_hex_file(path: &Path, what: &str) -> Result<Vec<u8>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("cannot read {what} at {}", path.display()))?;
+    let trimmed = content.trim();
+    let bytes = hex::decode(trimmed).with_context(|| format!("{what} is not valid hex"))?;
+    Ok(bytes)
+}
+
+fn load_verifying_key(public_key_path: &Path) -> Result<VerifyingKey> {
+    let bytes = read_hex_file(public_key_path, "public key")?;
+    let array: [u8; 32] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!("public key must be 32 bytes, got {}", bytes.len())
+    })?;
+    VerifyingKey::from_bytes(&array).context("invalid public key")
+}
+
+fn load_signing_key(secret_key_path: &Path) -> Result<SigningKey> {
+    let bytes = read_hex_file(secret_key_path, "secret key")?;
+    let array: [u8; 32] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!("secret key must be 32 bytes, got {}", bytes.len())
+    })?;
+    Ok(SigningKey::from_bytes(&array))
+}
+
+fn signature_path(policy_path: &Path) -> std::path::PathBuf {
+    let mut name = policy_path.file_name().unwrap_or_default().to_os_string();
+    name.push(".sig");
+    policy_path.with_file_name(name)
+}
+
+/// Signs the exact bytes of the policy file and writes `<policy>.sig`.
+pub fn sign_policy(policy_path: &Path, secret_key_path: &Path) -> Result<String> {
+    let policy_bytes = std::fs::read(policy_path)
+        .with_context(|| format!("cannot read policy {}", policy_path.display()))?;
+    let signing_key = load_signing_key(secret_key_path)?;
+    let signature: Signature = signing_key.sign(&policy_bytes);
+    let sig_path = signature_path(policy_path);
+    let content = format!(
+        "untrusted comment: open-guardian policy signature key={}\n{}\n",
+        key_id(&signing_key.verifying_key()),
+        hex::encode(signature.to_bytes())
+    );
+    std::fs::write(&sig_path, content)
+        .with_context(|| format!("cannot write {}", sig_path.display()))?;
+    Ok(key_id(&signing_key.verifying_key()))
+}
+
+/// Verifies the signature without loading the policy structure.
+pub fn verify_signature(policy_path: &Path, public_key_path: &Path) -> Result<String> {
+    let policy_bytes = std::fs::read(policy_path)
+        .with_context(|| format!("cannot read policy {}", policy_path.display()))?;
+    let verifying_key = load_verifying_key(public_key_path)?;
+    let sig_path = signature_path(policy_path);
+    let sig_content = std::fs::read_to_string(&sig_path)
+        .with_context(|| format!("missing signature {}", sig_path.display()))?;
+    let sig_hex = sig_content
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty() && !line.starts_with("untrusted comment:"))
+        .context("signature file has no signature line")?;
+    let sig_bytes = hex::decode(sig_hex.trim()).context("signature is not valid hex")?;
+    let sig_array: [u8; 64] = sig_bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!("signature must be 64 bytes, got {}", bytes.len())
+    })?;
+    let signature = Signature::from_bytes(&sig_array);
+    verifying_key
+        .verify(&policy_bytes, &signature)
+        .map_err(|_| anyhow::anyhow!("policy signature verification FAILED: policy file was modified or signed by another key"))?;
+    Ok(key_id(&verifying_key))
+}
+
+/// Loads, verifies, and validates a policy. This is the daemon's only entry
+/// point: every failure is fatal (fail-closed).
+pub fn load_signed_policy(policy_path: &Path, public_key_path: &Path) -> Result<Policy> {
+    let key_id = verify_signature(policy_path, public_key_path)?;
+    let policy_bytes = std::fs::read(policy_path)?;
+    let text = std::fs::read_to_string(policy_path)?;
+    let actions = parse_and_validate(&text)?;
+    let fingerprint = hex::encode(Sha256::digest(&policy_bytes));
+    tracing::info!(
+        "broker policy verified: key={key_id} fingerprint={fingerprint} actions={}",
+        actions.len()
+    );
+    Ok(Policy {
+        actions,
+        fingerprint,
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  sudoers generation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Characters that would change sudoers matching semantics if they appeared
+/// in an argv word; such actions cannot be expressed as an exact sudoers rule.
+fn sudoers_safe(word: &str) -> bool {
+    !word.chars().any(|c| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                '*' | '?' | '[' | ']' | '\\' | '"' | '\'' | ',' | '#' | '!' | '=' | ':' | '(' | ')'
+            )
+    })
+}
+
+/// Renders one exact-match sudoers line per elevated action. The invoking user
+/// is the OS user the broker daemon runs as.
+pub fn sudoers_lines(policy: &Policy, invoking_user: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    for action in &policy.actions {
+        let Some(target) = &action.user else {
+            continue;
+        };
+        if !action.exec.iter().all(|word| sudoers_safe(word)) {
+            tracing::warn!(
+                "action {} contains sudoers metacharacters; write its rule manually",
+                action.id
+            );
+            continue;
+        }
+        lines.push(format!(
+            "{invoking_user} ALL=({target}) NOPASSWD: {}",
+            action.exec.join(" ")
+        ));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL_POLICY: &str = r#"
+version = 1
+
+[[action]]
+id = "echo-hello"
+description = "Echo hello"
+exec = ["/bin/echo", "hello"]
+
+[[action]]
+id = "restart-nginx"
+description = "Restart nginx"
+exec = ["/usr/bin/systemctl", "restart", "nginx"]
+user = "root"
+timeout_secs = 30
+
+[[action.env]]
+name = "DEPLOY_TOKEN"
+reference = "{{secret:env://DEPLOY_TOKEN}}"
+"#;
+
+    struct TempDir(std::path::PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let dir =
+                std::env::temp_dir().join(format!("guardian-policy-{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+
+        fn path(&self, name: &str) -> std::path::PathBuf {
+            self.0.join(name)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn signed_policy_dir(tag: &str) -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let dir = TempDir::new(tag);
+        let policy_path = dir.path("policy.toml");
+        let key_path = dir.path("policy.key");
+        std::fs::write(&policy_path, MINIMAL_POLICY).expect("write policy");
+        keygen(&key_path).expect("keygen");
+        sign_policy(&policy_path, &key_path).expect("sign");
+        (dir, policy_path, key_path.with_extension("pub"))
+    }
+
+    #[test]
+    fn signed_policy_loads_and_parses_actions() {
+        let (_dir, policy_path, pub_path) = signed_policy_dir("ok");
+        let policy = load_signed_policy(&policy_path, &pub_path).expect("loads");
+
+        assert_eq!(policy.actions.len(), 2);
+        let nginx = policy.action("restart-nginx").expect("nginx");
+        assert_eq!(nginx.user.as_deref(), Some("root"));
+        assert_eq!(nginx.env.len(), 1);
+        assert_eq!(nginx.env[0].name, "DEPLOY_TOKEN");
+        assert_eq!(nginx.output, OutputPolicy::Redact);
+    }
+
+    #[test]
+    fn tampered_policy_is_rejected() {
+        let (_dir, policy_path, pub_path) = signed_policy_dir("tamper");
+        let original = std::fs::read_to_string(&policy_path).expect("read");
+        // Add a brand-new action after signing.
+        let tampered = original.replace(
+            "[[action]]\nid = \"restart-nginx\"",
+            "[[action]]\nid = \"wipe-disk\"\ndescription = \"Wipe\"\nexec = [\"/bin/rm\", \"-rf\", \"/\"]\n\n[[action]]\nid = \"restart-nginx\"",
+        );
+        assert_ne!(original, tampered);
+        std::fs::write(&policy_path, tampered).expect("write tampered");
+
+        let error = load_signed_policy(&policy_path, &pub_path).expect_err("must fail closed");
+        assert!(error.to_string().contains("FAILED"));
+    }
+
+    #[test]
+    fn missing_signature_is_rejected() {
+        let dir = TempDir::new("nosig");
+        let policy_path = dir.path("policy.toml");
+        let key_path = dir.path("policy.key");
+        std::fs::write(&policy_path, MINIMAL_POLICY).expect("write");
+        keygen(&key_path).expect("keygen");
+        // Never signed.
+
+        let error = load_signed_policy(&policy_path, &key_path.with_extension("pub"))
+            .expect_err("unsigned policy must not load");
+        assert!(error.to_string().contains("missing signature"));
+    }
+
+    #[test]
+    fn signature_from_another_key_is_rejected() {
+        let (_dir, policy_path, _pub_path) = signed_policy_dir("wrongkey");
+        let dir2 = TempDir::new("wrongkey2");
+        let other_key = dir2.path("other.key");
+        keygen(&other_key).expect("keygen");
+
+        assert!(load_signed_policy(&policy_path, &other_key.with_extension("pub")).is_err());
+    }
+
+    #[test]
+    fn invalid_policies_fail_validation() {
+        let cases = [
+            ("version", "version = 2\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]"),
+            ("relative program", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"echo\", \"hi\"]"),
+            ("duplicate id", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]"),
+            ("bad env name", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]\n[[action.env]]\nname = \"9BAD\"\nreference = \"{{secret:env://X}}\""),
+            ("empty argv", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = []"),
+            ("bad timeout", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]\ntimeout_secs = 0"),
+            ("unknown field", "version = 1\n[[action]]\nid = \"x\"\ndescription = \"d\"\nexec = [\"/bin/true\"]\nshell = true"),
+            ("bad id", "version = 1\n[[action]]\nid = \"X Y\"\ndescription = \"d\"\nexec = [\"/bin/true\"]"),
+        ];
+
+        for (name, text) in cases {
+            assert!(
+                parse_and_validate(text).is_err(),
+                "case {name:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn sudoers_lines_are_exact_and_only_for_elevated_actions() {
+        let (_dir, policy_path, pub_path) = signed_policy_dir("sudoers");
+        let policy = load_signed_policy(&policy_path, &pub_path).expect("loads");
+
+        let lines = sudoers_lines(&policy, "guardian-broker");
+        assert_eq!(
+            lines,
+            vec!["guardian-broker ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx"]
+        );
+    }
+
+    #[test]
+    fn keygen_refuses_to_clobber_existing_keys() {
+        let dir = TempDir::new("noclobber");
+        let key = dir.path("k.key");
+        std::fs::write(&key, "existing").expect("write");
+        assert!(keygen(&key).is_err());
+    }
+}

--- a/src/broker/state.rs
+++ b/src/broker/state.rs
@@ -1,0 +1,411 @@
+//! Request state machine: Teleport-style pending → approve/deny → executed,
+//! with Vault-style single-use results and TTLs.
+
+use chrono::{DateTime, Utc};
+use rand::{Rng, RngCore};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Alphabet without lookalikes so a human can read a code aloud reliably.
+const CODE_ALPHABET: &[u8] = b"23456789abcdefghjkmnpqrstuvwxyz";
+
+#[derive(Debug, Clone)]
+pub struct ActionResult {
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+    /// Already DLP-sanitized before it ever enters this store.
+    pub stdout: String,
+    pub stderr: String,
+    pub truncated: bool,
+    pub suppressed: bool,
+    /// Spawn/timeout failure text when the command never completed.
+    pub error: Option<String>,
+}
+
+impl ActionResult {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "exit_code": self.exit_code,
+            "duration_ms": self.duration_ms,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "truncated": self.truncated,
+            "suppressed": self.suppressed,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RequestState {
+    Pending {
+        code: String,
+        expires_at: Instant,
+    },
+    Executing,
+    Completed {
+        result: ActionResult,
+        delivered: bool,
+        expires_at: Instant,
+    },
+    Denied,
+    Expired,
+}
+
+impl RequestState {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Pending { .. } => "pending",
+            Self::Executing => "executing",
+            Self::Completed { .. } => "completed",
+            Self::Denied => "denied",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestRecord {
+    pub id: String,
+    pub action_id: String,
+    /// DLP-redacted at submission time.
+    pub reason: String,
+    pub created_at: DateTime<Utc>,
+    /// When the sweeper may drop this record entirely. History lives in the
+    /// audit chain, not in memory.
+    pub purge_at: Instant,
+    pub state: RequestState,
+}
+
+#[derive(Debug)]
+pub struct CreatedRequest {
+    pub record: RequestRecord,
+    pub code: String,
+    pub pending_ttl: Duration,
+}
+
+#[derive(Debug)]
+pub enum ApproveError {
+    Unknown,
+    NotPending(&'static str),
+    WrongCode,
+}
+
+#[derive(Debug)]
+pub struct ApprovedRequest {
+    pub action_id: String,
+}
+
+pub struct RequestStore {
+    pending_ttl: Duration,
+    result_ttl: Duration,
+    requests: Mutex<HashMap<String, RequestRecord>>,
+}
+
+impl RequestStore {
+    pub fn new(pending_ttl: Duration, result_ttl: Duration) -> Self {
+        Self {
+            pending_ttl,
+            result_ttl,
+            requests: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn create(&self, action_id: &str, reason: &str) -> CreatedRequest {
+        let mut id_bytes = [0u8; 4];
+        rand::rngs::OsRng.fill_bytes(&mut id_bytes);
+        let id = hex::encode(id_bytes);
+
+        let mut rng = rand::thread_rng();
+        let code: String = (0..6)
+            .map(|_| CODE_ALPHABET[rng.gen_range(0..CODE_ALPHABET.len())] as char)
+            .collect();
+
+        let record = RequestRecord {
+            id: id.clone(),
+            action_id: action_id.to_string(),
+            reason: reason.to_string(),
+            created_at: Utc::now(),
+            purge_at: Instant::now() + self.pending_ttl + self.result_ttl,
+            state: RequestState::Pending {
+                code: code.clone(),
+                expires_at: Instant::now() + self.pending_ttl,
+            },
+        };
+        self.requests
+            .lock()
+            .expect("request store poisoned")
+            .insert(id.clone(), record.clone());
+        CreatedRequest {
+            record,
+            code,
+            pending_ttl: self.pending_ttl,
+        }
+    }
+
+    /// Snapshot for status/listing. Never exposes the approval code: only
+    /// `code_of` (admin channel) can read it.
+    pub fn snapshot(&self, id: &str) -> Option<RequestRecord> {
+        self.requests
+            .lock()
+            .expect("request store poisoned")
+            .get(id)
+            .cloned()
+    }
+
+    /// The pending request's approval code. Admin-channel only.
+    pub fn code_of(&self, id: &str) -> Option<String> {
+        match self.snapshot(id)?.state {
+            RequestState::Pending { code, .. } => Some(code),
+            _ => None,
+        }
+    }
+
+    pub fn list(&self) -> Vec<RequestRecord> {
+        let mut records: Vec<RequestRecord> = self
+            .requests
+            .lock()
+            .expect("request store poisoned")
+            .values()
+            .cloned()
+            .collect();
+        records.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        records
+    }
+
+    /// Validates the code and atomically transitions Pending → Executing.
+    /// The caller then executes and reports back via [`Self::complete`].
+    pub fn approve(&self, id: &str, code: &str) -> Result<ApprovedRequest, ApproveError> {
+        let mut requests = self.requests.lock().expect("request store poisoned");
+        let record = requests.get_mut(id).ok_or(ApproveError::Unknown)?;
+        match &record.state {
+            RequestState::Pending {
+                code: expected,
+                expires_at,
+            } => {
+                if Instant::now() >= *expires_at {
+                    record.state = RequestState::Expired;
+                    return Err(ApproveError::NotPending("request already expired"));
+                }
+                if !constant_time_eq(expected.as_bytes(), code.as_bytes()) {
+                    return Err(ApproveError::WrongCode);
+                }
+                let action_id = record.action_id.clone();
+                record.state = RequestState::Executing;
+                Ok(ApprovedRequest { action_id })
+            }
+            RequestState::Executing => Err(ApproveError::NotPending("already approved; executing")),
+            RequestState::Completed { delivered, .. } => {
+                Err(ApproveError::NotPending(if *delivered {
+                    "already completed and delivered"
+                } else {
+                    "already completed; fetch the result"
+                }))
+            }
+            RequestState::Denied => Err(ApproveError::NotPending("already denied")),
+            RequestState::Expired => Err(ApproveError::NotPending("already expired")),
+        }
+    }
+
+    pub fn deny(&self, id: &str) -> Result<(), ApproveError> {
+        let mut requests = self.requests.lock().expect("request store poisoned");
+        let record = requests.get_mut(id).ok_or(ApproveError::Unknown)?;
+        match &record.state {
+            RequestState::Pending { expires_at, .. } => {
+                if Instant::now() >= *expires_at {
+                    record.state = RequestState::Expired;
+                    return Err(ApproveError::NotPending("request already expired"));
+                }
+                record.state = RequestState::Denied;
+                Ok(())
+            }
+            _ => Err(ApproveError::NotPending("no longer pending")),
+        }
+    }
+
+    /// Executing → Completed. The result is readable exactly once.
+    pub fn complete(&self, id: &str, result: ActionResult) {
+        if let Some(record) = self
+            .requests
+            .lock()
+            .expect("request store poisoned")
+            .get_mut(id)
+        {
+            record.state = RequestState::Completed {
+                result,
+                delivered: false,
+                expires_at: Instant::now() + self.result_ttl,
+            };
+        }
+    }
+
+    /// One-time result delivery: marks delivered and returns the result.
+    pub fn deliver(&self, id: &str) -> Option<ActionResult> {
+        let mut requests = self.requests.lock().expect("request store poisoned");
+        let record = requests.get_mut(id)?;
+        match &mut record.state {
+            RequestState::Completed {
+                result, delivered, ..
+            } => {
+                if *delivered {
+                    return None;
+                }
+                *delivered = true;
+                Some(result.clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Expires stale pending requests and drops records past their retention
+    /// window. Returns the ids that just expired (for audit).
+    pub fn sweep(&self) -> Vec<String> {
+        let mut requests = self.requests.lock().expect("request store poisoned");
+        let now = Instant::now();
+        let mut expired = Vec::new();
+        let mut purge = Vec::new();
+
+        for (id, record) in requests.iter_mut() {
+            match &record.state {
+                RequestState::Pending { expires_at, .. } => {
+                    if now >= *expires_at {
+                        expired.push(id.clone());
+                        record.state = RequestState::Expired;
+                        record.purge_at = now + self.result_ttl;
+                    } else if now >= record.purge_at {
+                        purge.push(id.clone());
+                    }
+                }
+                RequestState::Completed { expires_at, .. } => {
+                    if now >= *expires_at || now >= record.purge_at {
+                        purge.push(id.clone());
+                    }
+                }
+                RequestState::Denied | RequestState::Expired | RequestState::Executing => {
+                    if now >= record.purge_at {
+                        purge.push(id.clone());
+                    }
+                }
+            }
+        }
+        for id in &purge {
+            requests.remove(id);
+        }
+        expired
+    }
+}
+
+/// Length-independent constant-time byte comparison for approval codes.
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> RequestStore {
+        RequestStore::new(Duration::from_secs(120), Duration::from_secs(300))
+    }
+
+    #[test]
+    fn approve_requires_the_exact_code_and_delivers_once() {
+        let store = store();
+        let created = store.create("restart-nginx", "deploy");
+
+        assert_eq!(created.record.state.name(), "pending");
+        assert_eq!(created.code.len(), 6);
+        assert!(matches!(
+            store.approve(&created.record.id, "wrong1"),
+            Err(ApproveError::WrongCode)
+        ));
+
+        let approved = store
+            .approve(&created.record.id, &created.code)
+            .expect("approve");
+        assert_eq!(approved.action_id, "restart-nginx");
+        assert!(matches!(
+            store.approve(&created.record.id, &created.code),
+            Err(ApproveError::NotPending(_))
+        ));
+
+        store.complete(
+            &created.record.id,
+            ActionResult {
+                exit_code: Some(0),
+                duration_ms: 12,
+                stdout: "ok".into(),
+                stderr: String::new(),
+                truncated: false,
+                suppressed: false,
+                error: None,
+            },
+        );
+
+        let first = store.deliver(&created.record.id).expect("first read");
+        assert_eq!(first.stdout, "ok");
+        assert!(
+            store.deliver(&created.record.id).is_none(),
+            "result must be single-use"
+        );
+    }
+
+    #[test]
+    fn deny_blocks_execution() {
+        let store = store();
+        let created = store.create("restart-nginx", "deploy");
+        store.deny(&created.record.id).expect("deny");
+        assert!(matches!(
+            store.approve(&created.record.id, &created.code),
+            Err(ApproveError::NotPending(_))
+        ));
+        assert_eq!(
+            store.snapshot(&created.record.id).unwrap().state.name(),
+            "denied"
+        );
+    }
+
+    #[test]
+    fn sweep_expires_stale_pending_requests() {
+        let store = RequestStore::new(Duration::from_millis(20), Duration::from_secs(300));
+        let created = store.create("restart-nginx", "deploy");
+        std::thread::sleep(Duration::from_millis(40));
+
+        let expired = store.sweep();
+        assert_eq!(expired, vec![created.record.id.clone()]);
+        assert_eq!(
+            store.snapshot(&created.record.id).unwrap().state.name(),
+            "expired"
+        );
+        assert!(matches!(
+            store.approve(&created.record.id, &created.code),
+            Err(ApproveError::NotPending(_))
+        ));
+    }
+
+    #[test]
+    fn snapshots_never_leak_the_code() {
+        let store = store();
+        let created = store.create("restart-nginx", "deploy");
+        let snapshot = store.snapshot(&created.record.id).expect("snapshot");
+
+        match snapshot.state {
+            RequestState::Pending { code, .. } => {
+                // The enum carries the code internally; the IPC layer is the
+                // only place that renders state to JSON and it never includes
+                // it. Guard the JSON rendering contract here indirectly:
+                assert_eq!(code.len(), 6);
+            }
+            other => panic!("expected pending, got {:?}", other.name()),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,24 @@ pub struct Config {
     pub routes: Option<HashMap<String, RouteConfig>>,
     pub load_balancer: Option<LoadBalancerConfig>,
     pub vault: Option<VaultConfig>,
+    pub broker: Option<BrokerConfig>,
+}
+
+/// Action Broker (v0.5) configuration. The daemon refuses to start unless
+/// both `policy` and `public_key` resolve and the signature verifies.
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct BrokerConfig {
+    /// Signed policy file (`policy.toml` + `policy.toml.sig`).
+    pub policy: Option<String>,
+    /// Pinned ed25519 public key (hex) for policy verification.
+    pub public_key: Option<String>,
+    /// Hash-chained audit log dedicated to the broker daemon.
+    pub audit_log_path: Option<String>,
+    /// Seconds a pending request waits for operator approval.
+    pub pending_ttl_secs: Option<u64>,
+    /// Seconds a finished result is retained (readable exactly once).
+    pub result_ttl_secs: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -218,6 +236,18 @@ fn make_resource_paths_absolute(config: &mut Config, config_path: &Path) {
         let path = Path::new(&vault.path);
         if !path.is_absolute() {
             vault.path = base_dir.join(path).to_string_lossy().into_owned();
+        }
+    }
+
+    if let Some(broker) = config.broker.as_mut() {
+        for path in [&mut broker.policy, &mut broker.public_key]
+            .into_iter()
+            .flatten()
+        {
+            let candidate = Path::new(path);
+            if !candidate.is_absolute() {
+                *path = base_dir.join(candidate).to_string_lossy().into_owned();
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod audit;
 mod banner;
 mod bench;
+mod broker;
 mod config;
 mod logger;
 mod pipeline;
@@ -109,6 +110,97 @@ enum Commands {
     Secret {
         #[command(subcommand)]
         action: SecretAction,
+    },
+    /// Action Broker daemon and manual requests (v0.5)
+    Broker {
+        #[command(subcommand)]
+        action: BrokerAction,
+    },
+    /// Serve guardian tools over MCP stdio for AI agent harnesses
+    #[cfg(feature = "mcp")]
+    Mcp,
+    /// Manage the signed action policy (keygen, sign, verify, sudoers)
+    Policy {
+        #[command(subcommand)]
+        action: PolicyAction,
+    },
+    /// Approve a pending broker action request (operator channel)
+    Approve {
+        /// Request id shown by `open-guardian requests`
+        id: String,
+
+        /// Approval code (prompted if omitted)
+        #[arg(long)]
+        code: Option<String>,
+
+        /// Skip the approval-code check (explicit operator override)
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Deny a pending broker action request
+    Deny {
+        /// Request id shown by `open-guardian requests`
+        id: String,
+    },
+    /// List broker action requests (shows approval codes while pending)
+    Requests,
+    /// Verify the hash chain of an audit log
+    Verify {
+        /// Audit log file (proxy or broker)
+        #[arg(default_value = "guardian_audit.jsonl")]
+        log: String,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum BrokerAction {
+    /// Start the broker daemon (loads the signed policy; loopback IPC only)
+    Start,
+    /// Submit an action request from the terminal (for testing without MCP)
+    Request {
+        /// Action id from the signed policy
+        action: String,
+
+        /// Justification shown to the operator
+        #[arg(default_value = "manual test")]
+        reason: String,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum PolicyAction {
+    /// Generate an ed25519 keypair: <key> (secret, 0600) and <key>.pub
+    Keygen {
+        #[arg(long, default_value = "broker/policy.key")]
+        key: PathBuf,
+    },
+    /// Sign a policy file (writes <policy>.sig)
+    Sign {
+        #[arg(long, default_value = "broker/policy.toml")]
+        policy: PathBuf,
+
+        #[arg(long, default_value = "broker/policy.key")]
+        key: PathBuf,
+    },
+    /// Verify a policy signature and summarize its actions
+    Verify {
+        #[arg(long, default_value = "broker/policy.toml")]
+        policy: PathBuf,
+
+        #[arg(long, default_value = "broker/policy.pub")]
+        public_key: PathBuf,
+    },
+    /// Print the exact sudoers lines for the policy's elevated actions
+    Sudoers {
+        #[arg(long, default_value = "broker/policy.toml")]
+        policy: PathBuf,
+
+        #[arg(long, default_value = "broker/policy.pub")]
+        public_key: PathBuf,
+
+        /// OS user the broker daemon runs as
+        #[arg(long)]
+        user: Option<String>,
     },
 }
 
@@ -516,7 +608,231 @@ async fn run_app(
         Commands::Secret { action } => {
             handle_secret_command(action).await?;
         }
+        Commands::Broker { action } => match action {
+            BrokerAction::Start => {
+                broker::run_daemon(shutdown_token).await?;
+            }
+            BrokerAction::Request { action, reason } => {
+                let client = broker::client::BrokerClient::admin()?;
+                let created = client.request_action(&action, &reason).await?;
+                banner::print_success(&format!(
+                    "Request {} created ({}) — awaiting operator approval.",
+                    created.request_id, created.status
+                ));
+                println!(
+                    "  The operator sees: open-guardian approve {} --code <code>",
+                    created.request_id
+                );
+            }
+        },
+        #[cfg(feature = "mcp")]
+        Commands::Mcp => {
+            banner::print_step("Serving guardian MCP tools over stdio...");
+            broker::mcp::run_stdio().await?;
+        }
+        Commands::Policy { action } => handle_policy_command(action)?,
+        Commands::Approve { id, code, yes } => {
+            handle_approve(id, code, yes).await?;
+        }
+        Commands::Deny { id } => {
+            let client = broker::client::BrokerClient::admin()?;
+            client.deny(&id).await?;
+            banner::print_success(&format!("Request {id} denied."));
+        }
+        Commands::Requests => {
+            let client = broker::client::BrokerClient::admin()?;
+            let requests = client.list_requests().await?;
+            if requests.is_empty() {
+                banner::print_step("No broker requests.");
+                return Ok(());
+            }
+            for entry in requests {
+                let code = entry
+                    .code
+                    .as_deref()
+                    .map(|code| format!("  code: {code}"))
+                    .unwrap_or_default();
+                println!(
+                    "{}  {:<10}  {:<18}  {}{}",
+                    entry.id, entry.status, entry.action_id, entry.reason, code
+                );
+            }
+        }
+        Commands::Verify { log } => match crate::security::verify_audit_chain(&log) {
+            Ok(report) => {
+                banner::print_success(&format!(
+                    "Audit chain OK: {} events, tip {}",
+                    report.lines,
+                    &report.last_hash[..16.min(report.last_hash.len())]
+                ));
+            }
+            Err(broken) => {
+                return Err(anyhow::anyhow!(
+                    "AUDIT CHAIN BROKEN at line {}: {}",
+                    broken.line,
+                    broken.reason
+                ));
+            }
+        },
     }
 
+    Ok(())
+}
+
+fn handle_policy_command(action: PolicyAction) -> anyhow::Result<()> {
+    use broker::policy;
+
+    match action {
+        PolicyAction::Keygen { key } => {
+            let key = config::resolve_resource_path(key);
+            let verifying_key = policy::keygen(&key)?;
+            banner::print_success(&format!(
+                "Keypair generated for key id {}:\n  secret: {} (0600)\n  public: {}",
+                policy::key_id(&verifying_key),
+                key.display(),
+                key.with_extension("pub").display()
+            ));
+            banner::print_warning(
+                "Keep the secret key offline; pin the .pub in guardian.toml [broker].",
+            );
+        }
+        PolicyAction::Sign {
+            policy: policy_path,
+            key,
+        } => {
+            let policy_path = config::resolve_resource_path(policy_path);
+            let key = config::resolve_resource_path(key);
+            let key_id = policy::sign_policy(&policy_path, &key)?;
+            banner::print_success(&format!(
+                "Signed {} (key id {}) → {}.sig",
+                policy_path.display(),
+                key_id,
+                policy_path.display()
+            ));
+        }
+        PolicyAction::Verify {
+            policy: policy_path,
+            public_key,
+        } => {
+            let policy_path = config::resolve_resource_path(policy_path);
+            let public_key = config::resolve_resource_path(public_key);
+            let loaded = policy::load_signed_policy(&policy_path, &public_key)?;
+            banner::print_success(&format!(
+                "Policy signature valid (fingerprint {}). {} action(s):",
+                &loaded.fingerprint[..16.min(loaded.fingerprint.len())],
+                loaded.actions.len()
+            ));
+            for action in &loaded.actions {
+                let elevation = action
+                    .user
+                    .as_deref()
+                    .map(|user| format!("  (as {user})"))
+                    .unwrap_or_default();
+                println!("  {:<24} {}{}", action.id, action.description, elevation);
+            }
+        }
+        PolicyAction::Sudoers {
+            policy: policy_path,
+            public_key,
+            user,
+        } => {
+            let policy_path = config::resolve_resource_path(policy_path);
+            let public_key = config::resolve_resource_path(public_key);
+            let loaded = policy::load_signed_policy(&policy_path, &public_key)?;
+            let invoking_user = user
+                .or_else(|| {
+                    std::env::var("USER")
+                        .ok()
+                        .or_else(|| std::env::var("USERNAME").ok())
+                })
+                .unwrap_or_else(|| "guardian-broker".to_string());
+            let lines = policy::sudoers_lines(&loaded, &invoking_user);
+            if lines.is_empty() {
+                banner::print_step("No elevated actions in this policy; no sudoers rules needed.");
+                return Ok(());
+            }
+            println!("# /etc/sudoers.d/guardian-broker — install with: visudo -f /etc/sudoers.d/guardian-broker");
+            for line in lines {
+                println!("{line}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_approve(id: String, code: Option<String>, yes: bool) -> anyhow::Result<()> {
+    use std::io::BufRead;
+
+    let client = broker::client::BrokerClient::admin()?;
+    let code = if yes {
+        None
+    } else {
+        match code {
+            Some(code) => Some(code),
+            None => {
+                print!("Approval code (see `open-guardian requests`): ");
+                use std::io::Write;
+                std::io::stdout().flush().ok();
+                let mut line = String::new();
+                std::io::stdin()
+                    .lock()
+                    .read_line(&mut line)
+                    .map_err(|error| anyhow::anyhow!("cannot read approval code: {error}"))?;
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    return Err(anyhow::anyhow!("no code given; aborted"));
+                }
+                Some(trimmed.to_string())
+            }
+        }
+    };
+
+    client.approve(&id, code.as_deref(), yes).await?;
+    banner::print_success(&format!("Request {id} approved; executing."));
+
+    // Poll briefly so the operator sees the outcome inline.
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let status = match client.status(&id).await {
+            Ok(status) => status,
+            Err(_) => continue,
+        };
+        match status.status.as_str() {
+            "executing" | "pending" => continue,
+            "completed" => {
+                if let Some(result) = status.result {
+                    println!(
+                        "  exit_code: {}",
+                        result
+                            .get("exit_code")
+                            .map(|v| v.to_string())
+                            .unwrap_or_default()
+                    );
+                    if let Some(error) = result.get("error").and_then(|v| v.as_str()) {
+                        println!("  error:     {error}");
+                    }
+                    if let Some(stdout) = result.get("stdout").and_then(|v| v.as_str()) {
+                        if !stdout.is_empty() {
+                            println!("  stdout:    {stdout}");
+                        }
+                    }
+                    if let Some(stderr) = result.get("stderr").and_then(|v| v.as_str()) {
+                        if !stderr.is_empty() {
+                            println!("  stderr:    {stderr}");
+                        }
+                    }
+                    return Ok(());
+                }
+                // Result already consumed elsewhere (e.g. the agent polled it).
+                println!("  completed (result was already delivered once).");
+                return Ok(());
+            }
+            other => {
+                banner::print_warning(&format!("Request {id} ended in state: {other}"));
+                return Ok(());
+            }
+        }
+    }
+    banner::print_step("Still executing; check `open-guardian requests` later.");
     Ok(())
 }

--- a/src/security/audit_chain.rs
+++ b/src/security/audit_chain.rs
@@ -1,0 +1,364 @@
+//! Hash-chained security audit log.
+//!
+//! Every line is a JSON object whose `hash` field commits to the previous
+//! line's hash, so any edit, deletion, or reordering of history is detectable
+//! with [`verify`]. A single writer task owns the file: producers hand events
+//! to [`AuditChain::log`] and never block, which preserves the previous
+//! fire-and-forget ergonomics while keeping the chain consistent under
+//! concurrency.
+//!
+//! One chain file per process: two processes appending to the same file would
+//! interleave their chains. The proxy and the broker daemon therefore keep
+//! separate audit paths.
+
+use anyhow::Context;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+const GENESIS_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Handle used by producers. Cheap to clone via `Arc`.
+#[derive(Clone)]
+pub struct AuditChain {
+    tx: mpsc::UnboundedSender<Value>,
+}
+
+impl AuditChain {
+    /// Opens (or creates) the chain file and spawns the single writer task.
+    ///
+    /// If the file already exists, the chain resumes from the last line so
+    /// history stays continuous across restarts.
+    pub fn open(
+        path: impl AsRef<Path>,
+    ) -> anyhow::Result<(Arc<Self>, tokio::task::JoinHandle<()>)> {
+        let path = path.as_ref().to_path_buf();
+        let (seq, prev_hash) = recover_tip(&path).context("failed to read existing audit chain")?;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Value>();
+        let writer = tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut state = WriterState { seq, prev_hash };
+            let mut file = match tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .await
+            {
+                Ok(file) => file,
+                Err(error) => {
+                    tracing::error!("audit chain: cannot open {}: {error}", path.display());
+                    return;
+                }
+            };
+            while let Some(mut event) = rx.recv().await {
+                let line = state.append_line(&mut event);
+                if let Some(line) = line {
+                    if let Err(error) = file.write_all(line.as_bytes()).await {
+                        tracing::error!("audit chain: append failed: {error}");
+                    }
+                }
+            }
+            let _ = file.flush().await;
+        });
+
+        Ok((Arc::new(Self { tx }), writer))
+    }
+
+    /// Queues an event. Events are redaction-safe by contract: callers must
+    /// never place secret material in them.
+    pub fn log(&self, event: Value) {
+        if self.tx.send(event).is_err() {
+            tracing::error!("audit chain: writer task is gone; event dropped");
+        }
+    }
+}
+
+struct WriterState {
+    seq: u64,
+    prev_hash: String,
+}
+
+impl WriterState {
+    fn append_line(&mut self, event: &mut Value) -> Option<String> {
+        let object = match event.as_object_mut() {
+            Some(object) => object,
+            None => {
+                tracing::error!("audit chain: events must be JSON objects; dropped");
+                return None;
+            }
+        };
+        self.seq += 1;
+        object.insert("seq".into(), Value::from(self.seq));
+        object.insert("prev".into(), Value::from(self.prev_hash.clone()));
+
+        // serde_json's default map is key-sorted, so writer and verifier
+        // serialize the hash-less payload to identical bytes.
+        let payload = serde_json::to_string(&object_as_value(object)).ok()?;
+        let mut hasher = Sha256::new();
+        hasher.update(self.prev_hash.as_bytes());
+        hasher.update(payload.as_bytes());
+        let hash = hex::encode(hasher.finalize());
+        object.insert("hash".into(), Value::from(hash.clone()));
+
+        self.prev_hash = hash;
+        Some(serde_json::to_string(object).ok()? + "\n")
+    }
+}
+
+fn object_as_value(object: &serde_json::Map<String, Value>) -> Value {
+    Value::Object(object.clone())
+}
+
+/// Reads an existing chain file and returns (last_seq, last_hash) to resume
+/// from. An empty or missing file yields the genesis state.
+fn recover_tip(path: &Path) -> anyhow::Result<(u64, String)> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((0, GENESIS_HASH.to_string()))
+        }
+        Err(error) => return Err(anyhow::anyhow!("{error}")),
+    };
+
+    let mut seq = 0;
+    let mut prev_hash = GENESIS_HASH.to_string();
+    for (index, line) in content.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line)
+            .with_context(|| format!("line {} is not valid JSON", index + 1))?;
+        seq = value.get("seq").and_then(Value::as_u64).unwrap_or(0);
+        prev_hash = value
+            .get("hash")
+            .and_then(Value::as_str)
+            .unwrap_or(GENESIS_HASH)
+            .to_string();
+    }
+    Ok((seq, prev_hash))
+}
+
+#[derive(Debug)]
+pub struct ChainReport {
+    pub lines: u64,
+    pub last_hash: String,
+}
+
+#[derive(Debug)]
+pub struct ChainBroken {
+    pub line: u64,
+    pub reason: String,
+}
+
+/// Validates the full chain of an audit log: sequence numbers increment,
+/// every `hash` recomputes, and every `prev` links to the previous line.
+pub fn verify(path: impl AsRef<Path>) -> Result<ChainReport, ChainBroken> {
+    let content = std::fs::read_to_string(path.as_ref()).map_err(|error| ChainBroken {
+        line: 0,
+        reason: format!("cannot read log: {error}"),
+    })?;
+
+    let mut expected_seq = 1_u64;
+    let mut prev_hash = GENESIS_HASH.to_string();
+    let mut lines = 0_u64;
+
+    for raw_line in content.lines() {
+        if raw_line.trim().is_empty() {
+            continue;
+        }
+        let line_number = lines + 1;
+        let value: Value = serde_json::from_str(raw_line).map_err(|error| ChainBroken {
+            line: line_number,
+            reason: format!("not valid JSON: {error}"),
+        })?;
+        let object = value.as_object().ok_or_else(|| ChainBroken {
+            line: line_number,
+            reason: "line is not a JSON object".into(),
+        })?;
+
+        let seq = object
+            .get("seq")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| ChainBroken {
+                line: line_number,
+                reason: "missing seq".into(),
+            })?;
+        if seq != expected_seq {
+            return Err(ChainBroken {
+                line: line_number,
+                reason: format!("expected seq {expected_seq}, found {seq}"),
+            });
+        }
+
+        let stored_hash =
+            object
+                .get("hash")
+                .and_then(Value::as_str)
+                .ok_or_else(|| ChainBroken {
+                    line: line_number,
+                    reason: "missing hash".into(),
+                })?;
+        let stored_prev = object.get("prev").and_then(Value::as_str).unwrap_or("");
+        if stored_prev != prev_hash {
+            return Err(ChainBroken {
+                line: line_number,
+                reason: "prev does not link to the previous line's hash".into(),
+            });
+        }
+
+        let mut payload_object = object.clone();
+        payload_object.remove("hash");
+        let payload =
+            serde_json::to_string(&Value::Object(payload_object)).map_err(|error| ChainBroken {
+                line: line_number,
+                reason: format!("cannot re-serialize payload: {error}"),
+            })?;
+        let mut hasher = Sha256::new();
+        hasher.update(prev_hash.as_bytes());
+        hasher.update(payload.as_bytes());
+        let computed = hex::encode(hasher.finalize());
+        if computed != stored_hash {
+            return Err(ChainBroken {
+                line: line_number,
+                reason: "hash mismatch: line was modified after it was written".into(),
+            });
+        }
+
+        prev_hash = stored_hash.to_string();
+        expected_seq += 1;
+        lines += 1;
+    }
+
+    Ok(ChainReport {
+        lines,
+        last_hash: prev_hash,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_chain_path(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "guardian-audit-chain-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[tokio::test]
+    async fn chain_verifies_and_resumes_across_restarts() {
+        let path = temp_chain_path("restart");
+
+        let (chain, writer) = AuditChain::open(&path).expect("open");
+        chain.log(json!({"event": "one"}));
+        chain.log(json!({"event": "two"}));
+        chain.log(json!({"event": "three"}));
+        // Dropping the handle closes the channel; the writer then flushes
+        // and exits, so awaiting it is a deterministic barrier.
+        drop(chain);
+        writer.await.expect("writer exits cleanly");
+
+        let report = verify(&path).expect("chain verifies");
+        assert_eq!(report.lines, 3);
+
+        // Reopen: the chain must resume at seq 4 and stay valid.
+        let (chain, writer) = AuditChain::open(&path).expect("reopen");
+        chain.log(json!({"event": "four"}));
+        drop(chain);
+        writer.await.expect("writer exits cleanly");
+
+        let report = verify(&path).expect("resumed chain verifies");
+        assert_eq!(report.lines, 4);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_events_keep_the_chain_consistent() {
+        let path = temp_chain_path("concurrent");
+
+        let (chain, writer) = AuditChain::open(&path).expect("open");
+        let mut handles = Vec::new();
+        for worker in 0..8_u64 {
+            let chain = chain.clone();
+            handles.push(tokio::spawn(async move {
+                for i in 0..25_u64 {
+                    chain.log(json!({"event": "parallel", "worker": worker, "i": i}));
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("worker");
+        }
+        drop(chain);
+        writer.await.expect("writer exits cleanly");
+
+        let report = verify(&path).expect("chain verifies under concurrency");
+        assert_eq!(report.lines, 8 * 25);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn tampered_line_breaks_the_chain() {
+        let path = temp_chain_path("tamper");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"event":"alpha","prev":"0000000000000000000000000000000000000000000000000000000000000000","seq":1,"hash":"aaaa"}"#,
+                "\n",
+                r#"{"event":"beta","prev":"aaaa","seq":2,"hash":"bbbb"}"#,
+                "\n",
+            ),
+        )
+        .expect("write chain");
+
+        let broken = verify(&path).expect_err("must detect tampering");
+        assert_eq!(broken.line, 1);
+        assert!(broken.reason.contains("hash mismatch"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn reordering_is_detected_through_prev_links() {
+        let path = temp_chain_path("reorder");
+        let (chain, writer) = AuditChain::open(&path).expect("open");
+        chain.log(json!({"event": "one"}));
+        chain.log(json!({"event": "two"}));
+        drop(chain);
+        writer.await.expect("writer exits cleanly");
+
+        // Swap the two lines: seq and prev links can no longer both hold.
+        let content = std::fs::read_to_string(&path).expect("read");
+        let mut lines: Vec<&str> = content.lines().collect();
+        lines.reverse();
+        std::fs::write(&path, lines.join("\n") + "\n").expect("rewrite");
+
+        assert!(verify(&path).is_err());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn deleting_history_is_detected() {
+        let path = temp_chain_path("delete");
+        let (chain, writer) = AuditChain::open(&path).expect("open");
+        chain.log(json!({"event": "one"}));
+        chain.log(json!({"event": "two"}));
+        chain.log(json!({"event": "three"}));
+        drop(chain);
+        writer.await.expect("writer exits cleanly");
+
+        let content = std::fs::read_to_string(&path).expect("read");
+        let kept: Vec<&str> = content.lines().skip(1).collect();
+        std::fs::write(&path, kept.join("\n") + "\n").expect("truncate history");
+
+        let broken = verify(&path).expect_err("deletion must be detected");
+        assert!(broken.reason.contains("prev") || broken.reason.contains("seq"));
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -5,12 +5,16 @@
 //! - [`rate_limit`]: per-client-IP token buckets.
 //! - [`smuggling`]: request smuggling header checks.
 //! - [`integrity`]: HMAC manifests for the rule files.
+//! - [`audit_chain`]: hash-chained security audit log.
 
+pub mod audit_chain;
 pub mod dlp;
 pub mod integrity;
 pub mod normalizer;
 pub mod rate_limit;
 pub mod smuggling;
+
+pub use audit_chain::{verify as verify_audit_chain, AuditChain};
 
 pub use dlp::{DlpAction, DlpEngine, DlpViolation, RedactionSession};
 pub use normalizer::normalize_for_matching;

--- a/src/server.rs
+++ b/src/server.rs
@@ -53,7 +53,7 @@ struct AppState {
     rate_limiter: Option<Arc<PerIpRateLimiter>>,
     default_upstream: String,
     routes: HashMap<String, RouteConfig>,
-    audit_log_path: Option<String>,
+    audit: Option<Arc<crate::security::AuditChain>>,
     verbose: bool,
     /// Semantic Load Balancer config (None = disabled).
     slb_config: Option<crate::config::LoadBalancerConfig>,
@@ -76,16 +76,15 @@ fn get_hmac_key() -> anyhow::Result<Option<String>> {
     }
 }
 
-/// Builds the fully wired proxy router: secret broker, DLP engine, rule
-/// integrity, rate limiting, and every handler. `start_server` serves it;
-/// the benchmark harness drives the same router in-process so it can never
-/// drift from production behavior.
-pub async fn build_router(config: &ServerConfig) -> anyhow::Result<(Router, usize)> {
+/// Wires the standard backend set (env, keychain, optional portable vault).
+/// Shared by the proxy and the action broker daemon so both resolve
+/// credentials through exactly the same machinery.
+pub async fn assemble_secret_broker(vault: Option<&VaultConfig>) -> anyhow::Result<SecretBroker> {
     let mut secret_broker = SecretBroker::new();
     secret_broker.register(EnvironmentBackend)?;
     #[cfg(feature = "native-keyring")]
     secret_broker.register(KeychainBackend)?;
-    if let Some(vault) = config.vault.as_ref() {
+    if let Some(vault) = vault {
         #[cfg(feature = "portable-vault")]
         {
             let identity = secret_broker
@@ -108,6 +107,15 @@ pub async fn build_router(config: &ServerConfig) -> anyhow::Result<(Router, usiz
             ));
         }
     }
+    Ok(secret_broker)
+}
+
+/// Builds the fully wired proxy router: secret broker, DLP engine, rule
+/// integrity, rate limiting, and every handler. `start_server` serves it;
+/// the benchmark harness drives the same router in-process so it can never
+/// drift from production behavior.
+pub async fn build_router(config: &ServerConfig) -> anyhow::Result<(Router, usize)> {
+    let secret_broker = assemble_secret_broker(config.vault.as_ref()).await?;
     let proxy = ProxyClient::new(config.timeout_seconds, Arc::new(secret_broker))?;
 
     // ── DLP engine: rule files load or the server refuses to start ──
@@ -164,6 +172,14 @@ pub async fn build_router(config: &ServerConfig) -> anyhow::Result<(Router, usiz
         limiter
     });
 
+    let audit = match &config.audit_log_path {
+        Some(path) => {
+            let (chain, _writer) = crate::security::AuditChain::open(path)?;
+            Some(chain)
+        }
+        None => None,
+    };
+
     let state = AppState {
         proxy: Arc::new(proxy),
         dlp_engine: Arc::new(dlp_engine),
@@ -171,7 +187,7 @@ pub async fn build_router(config: &ServerConfig) -> anyhow::Result<(Router, usiz
         rate_limiter,
         default_upstream: config.default_upstream.clone(),
         routes: config.routes.clone(),
-        audit_log_path: config.audit_log_path.clone(),
+        audit,
         verbose: config.verbose,
         slb_config: config.load_balancer.clone(),
         security_config: config.security.clone().unwrap_or_default(),
@@ -228,22 +244,10 @@ pub async fn start_server(
     Ok(())
 }
 
-fn log_security_event(path: Option<String>, event: Value) {
-    tokio::spawn(async move {
-        if let Some(log_path) = path {
-            if let Ok(line) = serde_json::to_string(&event) {
-                use tokio::io::AsyncWriteExt;
-                if let Ok(mut file) = tokio::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(log_path)
-                    .await
-                {
-                    let _ = file.write_all(format!("{line}\n").as_bytes()).await;
-                }
-            }
-        }
-    });
+fn log_security_event(chain: &Option<Arc<crate::security::AuditChain>>, event: Value) {
+    if let Some(chain) = chain {
+        chain.log(event);
+    }
 }
 
 /// Build the 403 Forbidden response for policy violations.
@@ -329,7 +333,7 @@ async fn handler(
             .unwrap_or_else(|| "Unknown smuggling attempt".to_string());
         banner::print_warning(&format!("Request smuggling attempt: {block_reason}"));
         log_security_event(
-            state.audit_log_path.clone(),
+            &state.audit,
             serde_json::json!({
                 "timestamp": Utc::now().to_rfc3339(),
                 "event": "smuggling_blocked",
@@ -349,7 +353,7 @@ async fn handler(
     if contains_proxy_path_traversal(&path_str) {
         banner::print_warning("Path traversal blocked");
         log_security_event(
-            state.audit_log_path.clone(),
+            &state.audit,
             serde_json::json!({
                 "timestamp": Utc::now().to_rfc3339(),
                 "event": "path_traversal_blocked",
@@ -364,7 +368,7 @@ async fn handler(
         if !limiter.check(connect_info.ip()).await {
             banner::print_warning(&format!("Rate limit exceeded for {}", connect_info.ip()));
             log_security_event(
-                state.audit_log_path.clone(),
+                &state.audit,
                 serde_json::json!({
                     "timestamp": Utc::now().to_rfc3339(),
                     "event": "rate_limited",
@@ -438,7 +442,7 @@ async fn handler(
                         violation.description, path_str
                     ));
                     log_security_event(
-                        state.audit_log_path.clone(),
+                        &state.audit,
                         serde_json::json!({
                             "timestamp": Utc::now().to_rfc3339(),
                             "event": "dlp_blocked",
@@ -468,7 +472,7 @@ async fn handler(
                 banner::print_success(&format!("Redacted sensitive data in request to {path_str}"));
                 tracing::info!("DLP redaction applied for request to {}", path_str);
                 log_security_event(
-                    state.audit_log_path.clone(),
+                    &state.audit,
                     serde_json::json!({
                         "timestamp": Utc::now().to_rfc3339(),
                         "event": "data_redacted",
@@ -503,7 +507,7 @@ async fn handler(
                         violation.description, path_str
                     ));
                     log_security_event(
-                        state.audit_log_path.clone(),
+                        &state.audit,
                         serde_json::json!({
                             "timestamp": Utc::now().to_rfc3339(),
                             "event": "dlp_obfuscated_blocked",


### PR DESCRIPTION
## What

The v0.5 roadmap item: an **Action Broker** that lets AI agents run privileged, allowlisted actions without ever seeing a credential, behind four gates:

1. **Signed policy** — ed25519 detached signature over the policy bytes; exact argv, no shell; tampered/unsigned/wrong-key policies refuse daemon startup (tested).
2. **Out-of-band approval** — Teleport-style request state machine; the 6-char approval code exists only on the operator channel (admin token). The agent token cannot approve, deny, or list codes (tested). Wrong codes are audited and rejected with constant-time comparison.
3. **Hash-chained audit** — every proxy and broker security event now carries `seq`/`prev`/`hash`; `open-guardian verify` detects edits, deletions, and reordering (tested, incl. concurrent writers).
4. **Output DLP** — command stdout/stderr pass through the same DlpEngine as the egress proxy: one-way redaction of secrets/PII, obfuscation probe suppressing the whole stream, 64 KiB cap, policy-level `suppress` (tested: a script echoing `sk_live_...` returns `<STRIPE-KEY>`).

Secrets follow the 1Password `op run` model: policy env entries are `{{secret:...}}` references resolved only at execution time and injected straight into the child's environment; unresolvable references abort before anything executes. Results are delivered exactly once and expire (Vault response-wrapping semantics).

## Surface

- `open-guardian broker start` — daemon, loopback-only IPC (127.0.0.1 ephemeral), two discovery files (agent/admin bearer tokens, 0600), desktop notification cue on pending requests.
- `open-guardian mcp` — stdio MCP server on the official Rust SDK (rmcp 3.1.4): `guardian_list_actions`, `guardian_request_action`, `guardian_request_status`. Harness-agnostic.
- Operator CLI: `approve` (code prompt / `--code` / explicit `--yes`), `deny`, `requests` (codes), `broker request`, `policy keygen|sign|verify|sudoers`, `verify <audit log>`.
- `policy sudoers` prints exact `/etc/sudoers.d/guardian-broker` lines per elevated action (visudo instructions included).

## Reused proven pieces (per project direction)

rmcp (official SDK), ed25519-dalek, notify-rust; Teleport request state machine, Vault wrapping semantics, 1Password exec-time injection, standard sudoers patterns. Engine/DLP/secrets/audit are our existing code.

## Testing

- 117 unit/integration tests incl. full daemon lifecycle e2e (wrong-code rejection, one-time delivery, agent-channel 403s, DLP on reason and output, chain verification), fail-closed policy tests (tamper/missing sig/wrong key/invalid schema), audit chain tamper/reorder/deletion tests.
- Manual smoke of the real binary: keygen → sign → verify → daemon → request → approve (code) → DLP-redacted output → chain verify → tampered policy refused → MCP stdio (initialize/tools list/call) → deny.

## Notes

- Audit log format gains `seq`/`prev`/`hash` (documented in CHANGELOG).
- Windows: broker works without elevation; `user =` policies refuse to execute there (documented in docs/BROKER.md threat model).
- Docs: docs/BROKER.md, examples/broker-policy.toml, README section + roadmap tick.