### PR TITLE
feat: v0.6.0 Context DLP — MCP gateway + sanitize CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           cp guardian.toml README.md CHANGELOG.md LICENSE "$package/"
           cp rules/*.toml "$package/rules/"
           cp docs/adr/*.md "$package/docs/adr/"
-          cp docs/BENCHMARK.md docs/BROKER.md docs/RELEASING.md "$package/docs/"
+          cp docs/BENCHMARK.md docs/BROKER.md docs/CONTEXT.md docs/RELEASING.md "$package/docs/"
           cp benchmarks/corpus/*.toml "$package/benchmarks/corpus/"
           cp examples/*.toml "$package/examples/"
           tar -C dist -czf "dist/${{ matrix.platform.archive }}" open-guardian
@@ -97,7 +97,7 @@ jobs:
           Copy-Item guardian.toml, README.md, CHANGELOG.md, LICENSE $package
           Copy-Item rules/*.toml "$package/rules/"
           Copy-Item docs/adr/*.md "$package/docs/adr/"
-          Copy-Item docs/BENCHMARK.md, docs/BROKER.md, docs/RELEASING.md "$package/docs/"
+          Copy-Item docs/BENCHMARK.md, docs/BROKER.md, docs/CONTEXT.md, docs/RELEASING.md "$package/docs/"
           Copy-Item benchmarks/corpus/*.toml "$package/benchmarks/corpus/"
           Copy-Item examples/*.toml "$package/examples/"
           Compress-Archive -Path $package -DestinationPath "dist/${{ matrix.platform.archive }}"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 # Carpetas de prueba
 deploy_test/
 logs/
+.zcode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.6.0 - Context DLP: clean tool output before it enters the model (2026-08-22)
+
+### New
+
+- **`open-guardian mcp-gateway -- <command>`**: wraps any MCP stdio server
+  and pipes the harness through it. Harness → downstream traffic forwards
+  verbatim; on the way back, every tool result (the JSON-RPC `CallToolResult`
+  shape — identified structurally, no request tracking needed) is sanitized
+  before it reaches the model. `initialize`, `tools/list`, notifications,
+  resources, prompts, and sampling pass through untouched, so the gateway is
+  invisible to both ends. Exits with the downstream's exit code.
+- **`open-guardian sanitize`**: stdin → stdout through the DLP engine, for
+  harness hooks and shell pipelines (`cat .env | open-guardian sanitize`);
+  `--file` reads from disk. Status messages go to stderr — stdout stays
+  pipe-clean. `--rules` (both commands) overrides the rules file for one
+  invocation.
+- **Shared sanitization pipeline**: Context DLP reuses the broker's output
+  rule verbatim — irreversible in-place redaction of secrets/PII
+  (`sk_live_…` → `<STRIPE-KEY>`), then an obfuscation probe that suppresses
+  the whole output when anything suspicious survives normalization
+  (fail-closed, corpus-proven). For tool results, redaction walks the entire
+  `result` tree (`content[].text`, `structuredContent` at any depth) and
+  probes JSON numbers too (bare-digit Luhn cards).
+
+### Fixed
+
+- Stdio-protocol subcommands (`mcp`, `mcp-gateway`, `sanitize`) no longer
+  print the startup banner or the config-loaded notice to stdout — stdout
+  carries MCP JSON-RPC frames / sanitized payload only. Strict harnesses
+  that reject non-protocol lines now work.
+
 ## v0.5.0 - Action Broker: privileged actions with out-of-band approval (2026-08-22)
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-guardian"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-guardian"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ $ open-guardian approve 4ddbc0b9 --code xquupe    # operator terminal
 Any MCP client works (`open-guardian mcp`, stdio, official Rust SDK). Full
 design, threat model, and sudoers guide in [docs/BROKER.md](docs/BROKER.md).
 
+## Context DLP (v0.6): clean tool output before it enters the model
+
+Tool output never crosses the egress proxy — it goes straight into the
+conversation. **Context DLP** runs it through the same engine first:
+
+- `open-guardian mcp-gateway -- <command>` wraps **any** MCP stdio server:
+  requests pass through verbatim; every tool result comes back redacted
+  (`sk_live_…` → `<STRIPE-KEY>`, emails → `<EMAIL>`; obfuscated secrets
+  suppress the whole result, fail-closed).
+- `open-guardian sanitize` filters stdin → stdout for harness hooks and
+  pipelines (`cat .env | open-guardian sanitize`).
+
+```json
+{ "mcpServers": { "github": { "command": "open-guardian",
+  "args": ["mcp-gateway", "--", "npx", "-y", "@modelcontextprotocol/server-github"] } } }
+```
+
+Design and threat model in [docs/CONTEXT.md](docs/CONTEXT.md).
+
 ## Quick start
 
 ```bash
@@ -200,8 +219,10 @@ design.
   via MCP + CLI with signed policies, out-of-band approval, surgical sudoers,
   and chained audit — the agent uses the credential without ever seeing it.
   Harness-agnostic by design. See [docs/BROKER.md](docs/BROKER.md).
-- **v0.6 — Context DLP**: sanitizing tool/command output before it enters
-  model context.
+- **v0.6 — Context DLP** ✔ *shipped*: tool output sanitized before it enters
+  model context — an MCP gateway that wraps any stdio server and redacts
+  every tool result, plus a `sanitize` filter for hooks and pipelines.
+  See [docs/CONTEXT.md](docs/CONTEXT.md).
 
 ## Threat model and non-goals
 

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -4,7 +4,7 @@
 > by hand: CI regenerates this document and rejects drift, and any leak or
 > missed detection on the gated corpus fails the build.
 
-- Engine: open-guardian v0.5.0
+- Engine: open-guardian v0.6.0
 - Rules file: `rules/secrets.toml` (5806 bytes, 27 rules)
 - Corpus: 73 cases
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,103 @@
+# Context DLP (v0.6)
+
+The egress proxy guards what leaves the machine; the Action Broker guards
+what the agent *executes*. **Context DLP** guards what enters the model's
+context: tool output is sanitized by the same DLP engine before the harness
+ever sees it.
+
+```
+harness ──stdio JSON-RPC──► open-guardian mcp-gateway ──► any MCP server
+harness ◄──sanitized──────── open-guardian mcp-gateway ◄── tool results
+```
+
+## The two surfaces
+
+### 1. `mcp-gateway`: wrap any MCP server
+
+`open-guardian mcp-gateway` spawns a downstream MCP stdio server and pipes
+the harness through it. Harness → downstream traffic is forwarded verbatim;
+on the way back, every **tool result** (the JSON-RPC `CallToolResult` shape)
+is sanitized before it reaches the model. Requests, notifications,
+`tools/list`, resources, prompts, and sampling pass through untouched — the
+gateway is invisible to both ends.
+
+```console
+$ open-guardian mcp-gateway -- npx -y @modelcontextprotocol/server-github
+```
+
+Harness config (Claude Code / any stdio-capable harness):
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "open-guardian",
+      "args": ["mcp-gateway", "--", "npx", "-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+`--rules <file>` swaps in another rules file (gitleaks format), like `bench`.
+It must appear **before** the `--` separator.
+
+The gateway exits with the downstream server's exit code; closing the
+harness session closes the downstream's stdin, ending it.
+
+### 2. `sanitize`: a filter for everything else
+
+`open-guardian sanitize` runs stdin through the engine and prints the result
+to stdout — for harness hooks, shell pipelines, and logs:
+
+```console
+$ cat .env.production | open-guardian sanitize
+STRIPE_KEY=<STRIPE-KEY>
+$ curl -s https://api.example.com/status | open-guardian sanitize
+$ open-guardian sanitize --file dump.txt
+```
+
+Status messages go to stderr; stdout stays pipe-clean.
+
+## What "sanitized" means
+
+Identical to the broker's output rule — one pipeline, three outcomes:
+
+1. **Plain secrets/PII** (API keys, cards, emails, phones, …) are **redacted
+   in place, irreversibly**: `sk_live_Qw…` becomes `<STRIPE-KEY>`. The model
+   keeps the structure of the output, never the value.
+2. **Obfuscated secrets** (percent/double-percent encoding, HTML entities,
+   zero-width characters, homoglyphs — anything that only surfaces after
+   normalization) **cannot be rewritten in place, so the whole output
+   suppresses**: `[output suppressed: potential obfuscated sensitive data
+   detected]`. Fail-closed, corpus-proven (see docs/BENCHMARK.md).
+3. **Clean output passes unchanged**, byte for byte.
+
+For tool results, redaction walks the entire `result` tree: `content[].text`
+and every string inside `structuredContent`, nested at any depth. JSON
+**numbers are probed too** — a bare-digit Luhn card serializes as a number —
+and replaced with their redacted form when redaction changes them.
+
+## Threat model (honest)
+
+- **Protects the context** from secrets and PII in tool output: a file
+  reader, a `curl`, a database client, or an MCP server that echoes
+  credentials no longer pastes them into the conversation.
+- **Not a boundary against a malicious downstream.** The wrapped server runs
+  as your user with your files; if it is compromised, it can exfiltrate
+  through its own channels. Use it against *accidental* leakage from
+  legitimate tools.
+- **Same trust domain as the harness.** Anything that can run the gateway can
+  also run the downstream directly; Context DLP is a safety net for the
+  context window, not an access-control system (that is the Action Broker's
+  job).
+- Binary content blocks (images, audio) pass through untouched — only text
+  values and JSON numbers are inspected.
+- Egress (what crosses the wire to providers) remains the proxy's job;
+  Context DLP covers the surface the proxy never sees: local tool output.
+
+## Rule files
+
+Context DLP loads the same `[security.dlp]` configuration as the proxy and
+the broker (`guardian.toml`), rules files included. Missing or invalid rule
+files are fatal — fail-closed, like everywhere else. `--rules` on the CLI
+overrides them for one invocation.

--- a/src/broker/execute.rs
+++ b/src/broker/execute.rs
@@ -3,7 +3,8 @@
 
 use super::policy::{ActionDef, OutputPolicy};
 use super::state::ActionResult;
-use crate::security::{normalize_for_matching, DlpEngine};
+use crate::context::sanitize_text;
+use crate::security::DlpEngine;
 use open_guardian::secrets::SecretBroker;
 use std::time::Instant;
 
@@ -11,7 +12,6 @@ use std::time::Instant;
 const MAX_OUTPUT_BYTES: usize = 64 * 1024;
 
 const SUPPRESSED_BY_POLICY: &str = "[output suppressed by policy]";
-const SUPPRESSED_BY_DLP: &str = "[output suppressed: potential obfuscated sensitive data detected]";
 
 /// Runs one allowlisted action and returns a fully sanitized result. This
 /// function never returns Err: execution problems (missing binary, timeout,
@@ -141,27 +141,21 @@ fn truncate(text: &str) -> (String, bool) {
     (text[..cut].to_string(), true)
 }
 
-/// Applies the policy's output rule plus the DLP pipeline: one-way redaction
-/// of plain secrets/PII, then an obfuscation probe on the redacted text —
-/// anything suspicious left after redaction suppresses the whole stream.
+/// Applies the policy's output rule; the Redact arm is the shared Context DLP
+/// pipeline (one-way redaction, then an obfuscation probe that suppresses the
+/// whole stream if anything suspicious survives).
 fn sanitize(policy: OutputPolicy, dlp: &DlpEngine, text: &str) -> String {
     if policy == OutputPolicy::Suppress {
         return SUPPRESSED_BY_POLICY.to_string();
     }
-    let redacted = dlp.redact_permanent(text);
-    if dlp
-        .check_violations(&normalize_for_matching(&redacted))
-        .is_some()
-    {
-        return SUPPRESSED_BY_DLP.to_string();
-    }
-    redacted
+    sanitize_text(text, dlp)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::DlpConfig;
+    use crate::context::SUPPRESSED_BY_DLP;
     use crate::security::DlpEngine;
 
     fn engine() -> DlpEngine {

--- a/src/broker/mcp.rs
+++ b/src/broker/mcp.rs
@@ -171,7 +171,7 @@ impl GuardianTools {
 
 #[tool_handler(
     name = "open-guardian",
-    version = "0.5.0",
+    version = "0.6.0",
     instructions = "Request privileged actions behind the operator's signed policy. Approval is always out-of-band; poll guardian_request_status for results."
 )]
 impl ServerHandler for GuardianTools {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -388,7 +388,9 @@ pub fn load_config() -> anyhow::Result<Config> {
         .map_err(|error| anyhow::anyhow!("failed to parse {}: {}", path.display(), error))?;
     make_resource_paths_absolute(&mut config, &path);
     normalize_credentials(&mut config)?;
-    banner::print_success(&format!("Loaded config from {}", path.display()));
+    // stderr: stdout belongs to protocol-carrying subcommands (mcp,
+    // mcp-gateway, sanitize) and must stay payload-only.
+    eprintln!(" ✔ Loaded config from {}", path.display());
     Ok(config)
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,335 @@
+//! Context DLP (v0.6): the same DLP engine that guards egress, applied to
+//! tool output *before* it enters the model's context.
+//!
+//! Two surfaces:
+//! - `open-guardian mcp-gateway -- <command>`: wraps any MCP stdio server and
+//!   rewrites every tool result (the JSON-RPC `CallToolResult` shape) on its
+//!   way up to the harness. Requests, notifications, and every other result
+//!   shape pass through untouched.
+//! - `open-guardian sanitize`: stdin → stdout through the engine, for harness
+//!   hooks and shell pipelines.
+//!
+//! Sanitization is the broker's output rule, shared verbatim: irreversible
+//! redaction of secrets/PII, then an obfuscation probe — text that still
+//! trips detection after normalization suppresses entirely.
+
+use crate::security::{normalize_for_matching, DlpEngine};
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub const SUPPRESSED_BY_DLP: &str =
+    "[output suppressed: potential obfuscated sensitive data detected]";
+
+/// Redacts secrets/PII irreversibly; text that still trips detection once
+/// normalized (obfuscation) suppresses entirely instead of leaking.
+pub fn sanitize_text(text: &str, engine: &DlpEngine) -> String {
+    let redacted = engine.redact_permanent(text);
+    if engine
+        .check_violations(&normalize_for_matching(&redacted))
+        .is_some()
+    {
+        return SUPPRESSED_BY_DLP.to_string();
+    }
+    redacted
+}
+
+/// Builds the DLP engine for the context surface. Rule files load or the
+/// command fails — same fail-closed contract as the proxy and the broker.
+/// `--rules` swaps in a single file (gitleaks format), like `bench`.
+pub fn build_engine(rules: Option<PathBuf>) -> anyhow::Result<DlpEngine> {
+    let file_config = crate::config::load_config()?;
+    let mut config = file_config
+        .security
+        .and_then(|security| security.dlp)
+        .unwrap_or_default();
+    if let Some(rules) = rules {
+        config.rules_files = vec![rules.display().to_string()];
+    }
+    DlpEngine::build(&config).map_err(|error| anyhow::anyhow!("DLP engine: {error}"))
+}
+
+/// A JSON-RPC message is a tool result iff it is a response whose `result`
+/// carries a `content` array — the CallToolResult shape. The other result
+/// shapes (`tools`, `contents`, `messages`) never carry tool output.
+fn is_tool_result(message: &Value) -> bool {
+    message
+        .get("result")
+        .and_then(|result| result.get("content"))
+        .is_some_and(|content| content.is_array())
+}
+
+/// Redacts every string in the tree in place. Numbers are probed too (a
+/// bare-digit Luhn card serializes as a JSON number) and replaced with their
+/// redacted form when redaction changes them.
+fn redact_tree(value: &mut Value, engine: &DlpEngine) {
+    match value {
+        Value::String(text) => *text = engine.redact_permanent(text),
+        Value::Number(number) => {
+            let raw = number.to_string();
+            let redacted = engine.redact_permanent(&raw);
+            if redacted != raw {
+                *value = Value::String(redacted);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_tree(item, engine);
+            }
+        }
+        Value::Object(fields) => {
+            for (_, item) in fields {
+                redact_tree(item, engine);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Sanitizes one newline-delimited JSON-RPC message. Lines that are not a
+/// tool result (requests, notifications, other responses, non-JSON) come
+/// back verbatim; modified messages come back re-serialized.
+pub fn sanitize_rpc_line(line: &str, engine: &DlpEngine) -> String {
+    let Ok(mut message) = serde_json::from_str::<Value>(line) else {
+        return line.to_string();
+    };
+    if !is_tool_result(&message) {
+        return line.to_string();
+    }
+    let Some(result) = message.get_mut("result") else {
+        return line.to_string();
+    };
+
+    redact_tree(result, engine);
+
+    let probe = serde_json::to_string(result).unwrap_or_default();
+    if engine
+        .check_violations(&normalize_for_matching(&probe))
+        .is_some()
+    {
+        // Obfuscated data survived redaction (encodings, homoglyphs); the
+        // value cannot be rewritten in place, so the result is replaced.
+        *result = json!({
+            "content": [{ "type": "text", "text": SUPPRESSED_BY_DLP }]
+        });
+    }
+
+    serde_json::to_string(&message).unwrap_or_else(|_| line.to_string())
+}
+
+/// Downstream → harness pump: sanitize every line of the wrapped server's
+/// stdout. Ends at EOF, forwarding everything it saw.
+pub(crate) fn pump_downstream<R: BufRead, W: Write>(
+    mut reader: R,
+    mut out: W,
+    engine: &DlpEngine,
+) -> std::io::Result<()> {
+    let mut raw = Vec::new();
+    loop {
+        raw.clear();
+        match reader.read_until(b'\n', &mut raw) {
+            Ok(0) => break,
+            Ok(_) => {
+                let line = String::from_utf8_lossy(&raw);
+                let trimmed = line.trim_end_matches(['\r', '\n']);
+                if trimmed.is_empty() {
+                    writeln!(out)?;
+                } else {
+                    writeln!(out, "{}", sanitize_rpc_line(trimmed, engine))?;
+                }
+                out.flush()?;
+            }
+            Err(_) => break,
+        }
+    }
+    out.flush()
+}
+
+/// Harness → downstream pump: verbatim bytes, no parsing. EOF on the harness
+/// side closes the downstream's stdin, ending the session.
+pub(crate) fn pump_upstream<R: BufRead, W: Write>(
+    mut reader: R,
+    mut writer: W,
+) -> std::io::Result<()> {
+    let mut buffer = Vec::new();
+    loop {
+        buffer.clear();
+        match reader.read_until(b'\n', &mut buffer) {
+            Ok(0) => break,
+            Ok(_) => {
+                writer.write_all(&buffer)?;
+                writer.flush()?;
+            }
+            Err(_) => break,
+        }
+    }
+    writer.flush()
+}
+
+/// Runs `command` as a downstream MCP stdio server and pipes the harness
+/// through it: harness → downstream verbatim, downstream → harness with every
+/// tool result sanitized. Returns the downstream's exit code.
+pub fn run_gateway(engine: Arc<DlpEngine>, command: &[String]) -> anyhow::Result<i32> {
+    let mut child = std::process::Command::new(&command[0])
+        .args(&command[1..])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("failed to start {}: {error}", command[0]))?;
+
+    let child_stdin = child.stdin.take().expect("piped stdin");
+    let child_stdout = child.stdout.take().expect("piped stdout");
+
+    let downstream = {
+        let engine = Arc::clone(&engine);
+        std::thread::spawn(move || {
+            let reader = std::io::BufReader::new(child_stdout);
+            let _ = pump_downstream(reader, std::io::stdout().lock(), &engine);
+        })
+    };
+
+    // Deliberately not joined: this thread blocks on the harness's stdin
+    // until the harness closes the session, which outlives the gateway.
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(std::io::stdin());
+        let _ = pump_upstream(reader, child_stdin);
+    });
+
+    let status = child.wait()?;
+    let _ = downstream.join();
+    Ok(status.code().unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DlpConfig;
+    use std::io::Cursor;
+
+    fn engine() -> DlpEngine {
+        // The repo's shipped rules give the engine real secret patterns
+        // (sk_live_*, gsk_*, etc.) alongside the built-in PII detectors.
+        DlpEngine::build(&DlpConfig::default()).expect("engine with shipped rules")
+    }
+
+    #[test]
+    fn plain_text_passes_unchanged() {
+        let output = sanitize_text("deployment finished in 12s", &engine());
+        assert_eq!(output, "deployment finished in 12s");
+    }
+
+    #[test]
+    fn secrets_are_redacted_from_text() {
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+        let output = sanitize_text(&format!("token={secret} ok"), &engine());
+        assert!(!output.contains(secret), "leaked: {output}");
+        assert!(output.contains("token="));
+    }
+
+    #[test]
+    fn obfuscated_secret_suppresses_whole_text() {
+        // Percent-encoded Groq key from the benchmark corpus: invisible to
+        // plain redaction, caught by the normalization probe.
+        let output = sanitize_text("use gsk_Qw3%45r5Ty7Ui9Op1As3DfGh please", &engine());
+        assert_eq!(output, SUPPRESSED_BY_DLP);
+    }
+
+    fn tool_result_line(text: &str) -> String {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":7,"result":{{"content":[{{"type":"text","text":{}}}]}}}}"#,
+            serde_json::json!(text)
+        )
+    }
+
+    #[test]
+    fn tool_result_text_is_sanitized() {
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+        let line = tool_result_line(&format!("here is the key {secret} for deploy"));
+        let output = sanitize_rpc_line(&line, &engine());
+        assert!(!output.contains(secret), "leaked: {output}");
+        let parsed: Value = serde_json::from_str(&output).expect("still valid JSON-RPC");
+        let texts: Vec<&str> = parsed["result"]["content"]
+            .as_array()
+            .expect("content array kept")
+            .iter()
+            .filter_map(|item| item["text"].as_str())
+            .collect();
+        assert_eq!(texts.len(), 1);
+        assert!(texts[0].contains("here is the key"));
+    }
+
+    #[test]
+    fn nested_structured_content_is_sanitized() {
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+        let line = format!(
+            r#"{{"jsonrpc":"2.0","id":3,"result":{{"content":[{{"type":"text","text":"done"}}],"structuredContent":{{"note":"env {secret}","nested":{{"deep":"mail a@b.com"}}}}}}}}"#
+        );
+        let output = sanitize_rpc_line(&line, &engine());
+        assert!(!output.contains(secret), "leaked: {output}");
+        assert!(!output.contains("a@b.com"), "PII leaked: {output}");
+        assert!(output.contains("done"));
+    }
+
+    #[test]
+    fn bare_number_secret_is_redacted() {
+        let line = r#"{"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"card"}],"structuredContent":{"card":4111111111111111}}}"#;
+        let output = sanitize_rpc_line(line, &engine());
+        assert!(!output.contains("4111111111111111"), "leaked: {output}");
+        let parsed: Value = serde_json::from_str(&output).expect("valid JSON");
+        assert!(parsed["result"]["structuredContent"]["card"].is_string());
+    }
+
+    #[test]
+    fn obfuscated_tool_result_is_replaced_with_notice() {
+        let line = tool_result_line("run with gsk_Qw3%45r5Ty7Ui9Op1As3DfGh now");
+        let output = sanitize_rpc_line(&line, &engine());
+        let parsed: Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(parsed["result"]["content"][0]["text"], SUPPRESSED_BY_DLP);
+    }
+
+    #[test]
+    fn non_tool_messages_pass_verbatim() {
+        let engine = engine();
+        let verbatim = [
+            r#"{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"echo text"}]}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"contents":[{"uri":"file:///a"}]}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"echo"}}"#,
+            "not json at all",
+        ];
+        for line in verbatim {
+            assert_eq!(sanitize_rpc_line(line, &engine), line);
+        }
+    }
+
+    #[test]
+    fn downstream_pump_sanitizes_only_tool_results() {
+        let secret = "sk_live_Qw3Er5Ty7Ui9Op1As3DfGh";
+        let input = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"protocolVersion\":\"2025-06-18\"}}}}\n\
+             {tool}\n\
+             not json\n",
+            tool = tool_result_line(&format!("leak {secret}"))
+        );
+        let mut output = Vec::new();
+        pump_downstream(Cursor::new(input.into_bytes()), &mut output, &engine()).expect("pump");
+        let output = String::from_utf8(output).expect("utf8");
+        let mut lines = output.lines();
+        let init = lines.next().expect("line 1");
+        assert!(init.contains("protocolVersion"));
+        let tool = lines.next().expect("line 2");
+        assert!(!tool.contains(secret), "leaked: {tool}");
+        assert!(tool.contains("leak"), "kept the surrounding text");
+        assert_eq!(lines.next(), Some("not json"));
+        assert_eq!(lines.next(), None);
+    }
+
+    #[test]
+    fn upstream_pump_forwards_bytes_verbatim() {
+        let input = b"{\"id\":1}\n{\"id\":2}\ntrailing without newline";
+        let mut output = Vec::new();
+        pump_upstream(Cursor::new(input.to_vec()), &mut output).expect("pump");
+        assert_eq!(output, input.to_vec());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod banner;
 mod bench;
 mod broker;
 mod config;
+mod context;
 mod logger;
 mod pipeline;
 mod proxy;
@@ -149,6 +150,26 @@ enum Commands {
         /// Audit log file (proxy or broker)
         #[arg(default_value = "guardian_audit.jsonl")]
         log: String,
+    },
+    /// Wrap an MCP stdio server and sanitize its tool outputs (Context DLP)
+    McpGateway {
+        /// DLP rules file override (before --)
+        #[arg(long)]
+        rules: Option<PathBuf>,
+
+        /// Downstream MCP server after --, e.g. -- npx -y @modelcontextprotocol/server-github
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Sanitize text through the DLP engine: stdin → stdout (hooks, pipelines)
+    Sanitize {
+        /// Read from this file instead of stdin
+        #[arg(long)]
+        file: Option<PathBuf>,
+
+        /// DLP rules file override
+        #[arg(long)]
+        rules: Option<PathBuf>,
     },
 }
 
@@ -460,7 +481,28 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let cli = Cli::parse();
-    banner::print_banner();
+
+    // Stdio-protocol subcommands own stdout (MCP JSON-RPC frames, sanitize
+    // pipes): nothing but their payload may be printed there.
+    let owns_stdout = {
+        #[cfg(feature = "mcp")]
+        {
+            matches!(
+                cli.command,
+                Commands::Mcp | Commands::McpGateway { .. } | Commands::Sanitize { .. }
+            )
+        }
+        #[cfg(not(feature = "mcp"))]
+        {
+            matches!(
+                cli.command,
+                Commands::McpGateway { .. } | Commands::Sanitize { .. }
+            )
+        }
+    };
+    if !owns_stdout {
+        banner::print_banner();
+    }
 
     // Create a cancellation token for local runs (e.g. Ctrl+C)
     let shutdown_token = tokio_util::sync::CancellationToken::new();
@@ -627,7 +669,8 @@ async fn run_app(
         },
         #[cfg(feature = "mcp")]
         Commands::Mcp => {
-            banner::print_step("Serving guardian MCP tools over stdio...");
+            // MCP stdio carries the protocol on stdout: status to stderr only.
+            eprintln!("➜ Serving guardian MCP tools over stdio...");
             broker::mcp::run_stdio().await?;
         }
         Commands::Policy { action } => handle_policy_command(action)?,
@@ -674,6 +717,32 @@ async fn run_app(
                 ));
             }
         },
+        Commands::McpGateway { rules, command } => {
+            // MCP stdio carries the protocol on stdout: status goes to
+            // stderr only, or the harness connection breaks.
+            eprintln!("➜ MCP gateway up: {}", command.join(" "));
+            let engine = context::build_engine(rules)?;
+            let code = context::run_gateway(std::sync::Arc::new(engine), &command)?;
+            std::process::exit(code);
+        }
+        Commands::Sanitize { file, rules } => {
+            let engine = context::build_engine(rules)?;
+            let bytes = match file {
+                Some(path) => std::fs::read(path)?,
+                None => {
+                    let mut buffer = Vec::new();
+                    std::io::Read::read_to_end(&mut std::io::stdin(), &mut buffer)?;
+                    buffer
+                }
+            };
+            let input = String::from_utf8_lossy(&bytes);
+            let output = context::sanitize_text(&input, &engine);
+            if output.contains(context::SUPPRESSED_BY_DLP) {
+                // stdout stays pipe-clean; hooks consume it verbatim.
+                eprintln!("⚠ output suppressed: potential obfuscated sensitive data detected");
+            }
+            print!("{output}");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## v0.6.0 — Context DLP

Tool output never crosses the egress proxy — it goes straight into the model's context. This release runs it through the same DLP engine first.

### New
- **`open-guardian mcp-gateway -- <command>`**: wraps any MCP stdio server and pipes the harness through it. Harness → downstream is verbatim; on the way back every tool result (the JSON-RPC `CallToolResult` shape, identified structurally — no request tracking) is sanitized before reaching the model. `initialize`, `tools/list`, notifications, resources, prompts, sampling: untouched. Exits with the downstream's exit code.
- **`open-guardian sanitize`**: stdin → stdout through the engine, for harness hooks and shell pipelines. `--file`, `--rules` on both commands. Status → stderr; stdout stays pipe-clean.
- **One shared sanitization pipeline** with the broker's output rule: irreversible in-place redaction (`sk_live_…` → `<STRIPE-KEY>`), then the obfuscation probe that suppresses whole output when anything suspicious survives normalization (fail-closed, corpus-proven). Tool-result redaction walks the entire `result` tree and probes JSON numbers (bare-digit Luhn cards).

### Fixed
- Stdio subcommands (`mcp`, `mcp-gateway`, `sanitize`) no longer print the banner/config notice to stdout — strict harnesses that reject non-protocol lines now work.

### Verified
- 127 tests green (10 new: RPC sanitization, verbatim passthrough shapes, obfuscation suppression, both pumps).
- Real-binary smoke: fake MCP server returning `sk_live_…` + email → harness receives `<STRIPE-KEY>` / `<EMAIL>` in `content[].text` **and** `structuredContent`; percent-encoded Groq key → whole result replaced with the suppression notice; `tools/list` byte-identical; gateway stdout pure JSON-RPC.
- Bench gate PASS, BENCHMARK.md regenerated (version line only).

No new dependencies. Docs: `docs/CONTEXT.md` (shipped in packages), README, CHANGELOG.